### PR TITLE
Feat: Swagger, QueryDSL, JPA 셋업 / 대피소 DB 구축

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -53,6 +53,18 @@ jobs:
         if: contains(github.ref, 'main')
         run: ./gradlew build -x test
 
+
+      - name:  docker-compose.yml to EC2 server
+        uses: appleboy/scp-action@master
+        with:
+          username: ubuntu
+          host: ${{ secrets.EC2_HOST }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          port: ${{ secrets.EC2_PORT }}
+          source: "./docker-compose.yml"
+          target: "/home/ubuntu/"
+
+
       ## docker build & push to production
       - name: Docker build & push to prod
         if: contains(github.ref, 'main')

--- a/build.gradle
+++ b/build.gradle
@@ -22,18 +22,57 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+	// jpa
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// queryDSL
+	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.8'
+
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	annotationProcessor 'org.projectlombok:lombok'
+
 	compileOnly 'org.projectlombok:lombok'
+
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
+
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(generated)
 }

--- a/src/main/java/com/numberone/backend/config/P6spyLogMessageFormatConfiguration.java
+++ b/src/main/java/com/numberone/backend/config/P6spyLogMessageFormatConfiguration.java
@@ -1,0 +1,14 @@
+package com.numberone.backend.config;
+
+import com.p6spy.engine.spy.P6SpyOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class P6spyLogMessageFormatConfiguration {
+    @PostConstruct
+    public void setLogMessageFormat() {
+        P6SpyOptions.getActiveInstance().setLogMessageFormat(P6spySqlFormatConfiguration.class.getName());
+    }
+}

--- a/src/main/java/com/numberone/backend/config/P6spySqlFormatConfiguration.java
+++ b/src/main/java/com/numberone/backend/config/P6spySqlFormatConfiguration.java
@@ -1,0 +1,33 @@
+package com.numberone.backend.config;
+
+import com.p6spy.engine.common.P6Util;
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+
+import java.util.Locale;
+
+public class P6spySqlFormatConfiguration implements MessageFormattingStrategy {
+    @Override
+    public String formatMessage(int connectionId, String now, long elapsed, String category, String prepared, String sql, String url) {
+        sql = formatSql(category, sql);
+        return now + "|" + elapsed + "ms|" + category + "|connection " + connectionId + "|" + P6Util.singleLine(prepared) + sql;
+    }
+
+    private String formatSql(String category, String sql) {
+        if (sql == null || sql.trim().equals("")) return sql;
+
+        // Only format Statement, distinguish DDL And DML
+        if (Category.STATEMENT.getName().equals(category)) {
+            String tmpsql = sql.trim().toLowerCase(Locale.ROOT);
+            if (tmpsql.startsWith("create") || tmpsql.startsWith("alter") || tmpsql.startsWith("comment")) {
+                sql = FormatStyle.DDL.getFormatter().format(sql);
+            } else {
+                sql = FormatStyle.BASIC.getFormatter().format(sql);
+            }
+            sql = "|\nHeFormatSql(P6Spy sql,Hibernate format):" + sql;
+        }
+
+        return sql;
+    }
+}

--- a/src/main/java/com/numberone/backend/config/SecurityConfig.java
+++ b/src/main/java/com/numberone/backend/config/SecurityConfig.java
@@ -27,6 +27,12 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring()
+                .requestMatchers("/h2-console/**",
+                        "/favicon.ico",
+                        "/error",
+                        "/swagger-ui/**",
+                        "/swagger-resources/**",
+                        "/v3/api-docs/**")
                 .requestMatchers("/*"); // 인증 처리 하지 않을 케이스
     }
 }

--- a/src/main/java/com/numberone/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/numberone/backend/config/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package com.numberone.backend.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        servers = @Server(url = "/", description = "${host.url}"),
+        info = @Info(
+                title = "🚀 대피로 백엔드 API 명세서",
+                description = """
+                        spring docs 를 이용한 API 명세서 입니다.😊
+                        """,
+                version = "1.0",
+                contact = @Contact(
+                        name = "springdoc 공식문서",
+                        url = "https://springdoc.org/"
+                )
+        )
+)
+@Configuration
+public class SwaggerConfig {
+}

--- a/src/main/java/com/numberone/backend/config/basetime/BaseTimeConfig.java
+++ b/src/main/java/com/numberone/backend/config/basetime/BaseTimeConfig.java
@@ -1,0 +1,17 @@
+package com.numberone.backend.config.basetime;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.TimeZone;
+
+@Configuration
+@EnableJpaAuditing
+public class BaseTimeConfig {
+
+    @PostConstruct
+    public void setSeoulTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+}

--- a/src/main/java/com/numberone/backend/config/basetime/BaseTimeEntity.java
+++ b/src/main/java/com/numberone/backend/config/basetime/BaseTimeEntity.java
@@ -1,0 +1,28 @@
+package com.numberone.backend.config.basetime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @Comment("최초 생성 시각")
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Comment("마지막 수정 시각")
+    @LastModifiedDate
+    @Column(name = "modified_at")
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/numberone/backend/domain/shelter/entity/Shelter.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/entity/Shelter.java
@@ -1,0 +1,42 @@
+package com.numberone.backend.domain.shelter.entity;
+
+import com.numberone.backend.config.basetime.BaseTimeEntity;
+import com.numberone.backend.domain.shelter.util.Address;
+import com.numberone.backend.domain.shelter.util.ShelterStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Comment("대피소 정보")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "SHELTER")
+public class Shelter extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "shelter_id")
+    private Long id;
+
+    @Comment("관리 코드(행정용)")
+    private String districtCode;
+
+    @Comment("관리 번호(행정용)")
+    private String managementNumber;
+
+    @Comment("대피소 운영 상태(OPEN/CLOSE)")
+    @Enumerated(EnumType.STRING)
+    private ShelterStatus status;
+
+    @Embedded
+    private Address address;
+
+    @Comment("시설 유형 이름")
+    private String facilityTypeName;
+
+    @Comment("시설 이름")
+    private String facilityFullName;
+
+}

--- a/src/main/java/com/numberone/backend/domain/shelter/repository/ShelterRepository.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/repository/ShelterRepository.java
@@ -1,0 +1,7 @@
+package com.numberone.backend.domain.shelter.repository;
+
+import com.numberone.backend.domain.shelter.entity.Shelter;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShelterRepository extends JpaRepository<Shelter, Long> {
+}

--- a/src/main/java/com/numberone/backend/domain/shelter/service/ShelterService.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/service/ShelterService.java
@@ -1,0 +1,13 @@
+package com.numberone.backend.domain.shelter.service;
+
+import com.numberone.backend.domain.shelter.repository.ShelterRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ShelterService {
+    private ShelterRepository shelterRepository;
+}

--- a/src/main/java/com/numberone/backend/domain/shelter/util/Address.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/util/Address.java
@@ -1,0 +1,30 @@
+package com.numberone.backend.domain.shelter.util;
+
+import jakarta.persistence.Embeddable;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@NoArgsConstructor
+@Embeddable
+public class Address {
+    @Comment("(구) 주소")
+    private String fullAddress;
+
+    @Comment("도로명 주소")
+    private String roadNameAddress;
+
+    @Comment("도로명 우편번호")
+    private String roadNamePostalCode;
+
+    @Comment("EPSG:2097 좌표 정보(x)")
+    private Double coordinateX;
+    @Comment("EPSG:2097 좌표 정보(y)")
+    private Double coordinateY;
+
+    @Comment("위도")
+    private Double latitude;
+
+    @Comment("경도")
+    private Double longitude;
+
+}

--- a/src/main/java/com/numberone/backend/domain/shelter/util/ShelterStatus.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/util/ShelterStatus.java
@@ -1,0 +1,10 @@
+package com.numberone.backend.domain.shelter.util;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ShelterStatus {
+    OPEN, // 정상 운영
+    CLOSE;  // 운영 중단
+    String value;
+}


### PR DESCRIPTION
- Close #8
- Close #9 

## 작업내용
- Swagger, QueryDSL 셋업 
- JPA 쿼리 이쁘게 보이도록 p6spy 설정
- 대피소(Shelter) 데이터베이스 구축 (약 4만개)
```
-- auto-generated definition
create table shelter
(
    coordinatex           double                 null comment 'EPSG:2097 좌표 정보(x)',
    coordinatey           double                 null comment 'EPSG:2097 좌표 정보(y)',
    latitude              double                 null comment '위도',
    longitude             double                 null comment '경도',
    shelter_id            bigint auto_increment
        primary key,
    district_code         varchar(255)           null comment '관리 코드(행정용)',
    facility_full_name    varchar(255)           null comment '시설 이름',
    facility_type_name    varchar(255)           null comment '시설 유형 이름',
    full_address          varchar(255)           null comment '(구) 주소',
    management_number     varchar(255)           null comment '관리 번호(행정용)',
    road_name_address     varchar(255)           null comment '도로명 주소',
    road_name_postal_code varchar(255)           null comment '도로명 우편번호',
    status                enum ('CLOSE', 'OPEN') null comment '대피소 운영 상태(OPEN/CLOSE)',
    created_at            datetime(6)            null comment '최초 생성 시각',
    modified_at           datetime(6)            null comment '마지막 수정 시각'
)
    comment '대피소 정보';
```

- JPA Auditing 을 통한 엔티티 생성 시각, 마지막 수정 시각 관리