### PR TITLE
Fix: 서비스계층 특정 메서드 readonly 해제

### DIFF
--- a/src/main/java/com/numberone/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/numberone/backend/domain/member/service/MemberService.java
@@ -18,6 +18,7 @@ public class MemberService {
                 .orElseThrow(NotFoundMemberException::new);
     }
 
+    @Transactional
     public void create(String email) {
         memberRepository.save(Member.of(email));
     }

--- a/src/main/java/com/numberone/backend/domain/token/dto/response/KakaoInfoResponse.java
+++ b/src/main/java/com/numberone/backend/domain/token/dto/response/KakaoInfoResponse.java
@@ -1,5 +1,6 @@
 package com.numberone.backend.domain.token.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.ToString;
 @ToString
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoInfoResponse {
     private Long id;
     private String connected_at;
@@ -17,6 +19,7 @@ public class KakaoInfoResponse {
     @ToString
     @Getter
     @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public class Properties {
         private String nickname;
         private String profile_image;
@@ -26,6 +29,7 @@ public class KakaoInfoResponse {
     @ToString
     @Getter
     @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public class KakaoAccount {
         static class profile {
             private String nickname;

--- a/src/main/java/com/numberone/backend/domain/token/dto/response/NaverInfoResponse.java
+++ b/src/main/java/com/numberone/backend/domain/token/dto/response/NaverInfoResponse.java
@@ -1,5 +1,6 @@
 package com.numberone.backend.domain.token.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.ToString;
 @ToString
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class NaverInfoResponse {
     private String resultcode;
     private String message;
@@ -16,6 +18,7 @@ public class NaverInfoResponse {
     @ToString
     @Getter
     @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public class Response {
         private String id;
         private String nickname;

--- a/src/main/java/com/numberone/backend/domain/token/service/TokenService.java
+++ b/src/main/java/com/numberone/backend/domain/token/service/TokenService.java
@@ -28,6 +28,7 @@ public class TokenService {
     private final TokenRepository tokenRepository;
     private final MemberRepository memberRepository;
 
+    @Transactional
     public TokenResponse loginKakao(TokenRequest tokenRequest) {
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-type", "application/x-www-form-urlencoded; charset=utf-8");
@@ -38,6 +39,7 @@ public class TokenService {
         return TokenResponse.of(getAccessToken(email));
     }
 
+    @Transactional
     public TokenResponse loginNaver(TokenRequest tokenRequest) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);


### PR DESCRIPTION
close #24 

- 사용자가 소셜로그인을 할때 어떤 권한들을 동의했냐에 따라서 카카오, 네이버 응답 json이 크게 달라지네요. 카카오,네이버서버 응답 json에는 존재하지만 매핑되는 dto 클래스에는 없는 필드가 있을 경우 오류가 발생할까봐 해당 dto 클래스에 @JsonIgnoreProperties(ignoreUnknown = true)를 적용해 주었습니다.
- 서비스 코드에서 클래스 단위에 Transactional(readonly=true)를 사용하였기 때문에 데이터를 db에 쓰는 모든 메서드의 경우 Transactional 어노테이션을 적용해야 했는데 빠트려서 버그가 있었네요! 해당 내용 수정하였습니다