### PR TITLE
Feat: 대피소 데이터 보강, API 추가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,10 @@ dependencies {
 
 	// cloud
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// aop
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/numberone/backend/config/AspectConfig.java
+++ b/src/main/java/com/numberone/backend/config/AspectConfig.java
@@ -1,0 +1,9 @@
+package com.numberone.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@EnableAspectJAutoProxy
+@Configuration
+public class AspectConfig {
+}

--- a/src/main/java/com/numberone/backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/numberone/backend/domain/admin/controller/AdminController.java
@@ -1,0 +1,37 @@
+package com.numberone.backend.domain.admin.controller;
+
+import com.numberone.backend.domain.admin.service.AdminService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @Operation(summary = "서버에 지역별 대피소 정보 Json 파일로 업로드하기", description =
+            """
+            
+            🔥 (주의) Shelter Database 정보를 json 형태로 요약하여 서버 스토리지에 저장하는 기능으로, 10 분 이상 소요됩니다.
+            
+            요청 시, 현재 저장된 대피소 db 를 기반으로
+            
+            지역 별 대피소 정보를 Json 형태로 정리하여 서버 스토리지에 저장합니다.
+            
+            대피소 db 를 업데이트 한 경우에, 실행하는 api 입니다. 
+            
+            """)
+    @GetMapping("/shelter-init")
+    public ResponseEntity<String> CreateShelterDatabaseJsonFile() {
+        return ResponseEntity.created(URI.create("/api/admin"))
+                .body(adminService.uploadShelterJsonFile());
+    }
+}

--- a/src/main/java/com/numberone/backend/domain/admin/service/AdminService.java
+++ b/src/main/java/com/numberone/backend/domain/admin/service/AdminService.java
@@ -10,7 +10,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.List;
 
 @Slf4j
@@ -28,16 +29,18 @@ public class AdminService {
     @Value("${storage-path.shelter-database-init-path}")
     private String databaseUploadPath;
 
-    public void getShelterDatabase() {
+    public String uploadShelterJsonFile() {
+        String filePath = "";
         try {
             List<GetAllSheltersResponse> result = shelterRepository.findAllSheltersGroupByRegions();
             String jsonResult = objectMapper.writeValueAsString(result);
             InputStream inputStream = new ByteArrayInputStream(jsonResult.getBytes());
-            s3Provider.uploadJsonFile(databaseUploadPath, inputStream);
             log.info("[파일 업로드 완료]");
+            filePath = s3Provider.uploadJsonFile(databaseUploadPath, inputStream);
         } catch (Exception e) {
             log.error("Shelter database 파일 생성 중 error 발생 {}", e.getMessage());
         }
+        return filePath;
     }
 
 }

--- a/src/main/java/com/numberone/backend/domain/admin/service/AdminService.java
+++ b/src/main/java/com/numberone/backend/domain/admin/service/AdminService.java
@@ -1,0 +1,43 @@
+package com.numberone.backend.domain.admin.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.numberone.backend.domain.shelter.dto.response.GetAllSheltersResponse;
+import com.numberone.backend.domain.shelter.repository.ShelterRepository;
+import com.numberone.backend.support.S3Provider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.*;
+import java.util.List;
+
+@Slf4j
+@RestController
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final ShelterRepository shelterRepository;
+
+    private final ObjectMapper objectMapper;
+
+    private final S3Provider s3Provider;
+
+    @Value("${storage-path.shelter-database-init-path}")
+    private String databaseUploadPath;
+
+    public void getShelterDatabase() {
+        try {
+            List<GetAllSheltersResponse> result = shelterRepository.findAllSheltersGroupByRegions();
+            String jsonResult = objectMapper.writeValueAsString(result);
+            InputStream inputStream = new ByteArrayInputStream(jsonResult.getBytes());
+            s3Provider.uploadJsonFile(databaseUploadPath, inputStream);
+            log.info("[파일 업로드 완료]");
+        } catch (Exception e) {
+            log.error("Shelter database 파일 생성 중 error 발생 {}", e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/numberone/backend/domain/shelter/controller/ShelterController.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/controller/ShelterController.java
@@ -25,9 +25,19 @@ public class ShelterController {
 
     @Operation(summary = "가장 가까운 대피소 정보 하나 가져오기", description =
             """
-            위도 경도를 body 에 담아서 post 요청 해주세요.
+            위도(latitude), 경도(longitude), 대피소 유형(shelterType),을 body 에 담아서 post 요청 해주세요.
+            
+            [ I ] shelterType 이 null 이면 대피소 유형에 상관 없이  
             
             가장 가까운 대피소 정보를 반환합니다.
+            
+            [ II ] shelterType 이 '민방위' 이면 민방위 대피소를 반환합니다.
+            
+            [ III ]  shelterType 이 '수해' 이면 수해(홍수 등등..) 대피소를 반환합니다.
+            
+            [ IV ] shelterType 이 '지진' 이면 지진 대피소를 반환합니다.
+            
+            (주의🔥) 대피소가 하나도 없는 경우에는 NotFound 예외를 터뜨립니다.
             
             distance 는 미터(m) 단위이며 1500 m 이내 대피소만 검색합니다.
             
@@ -39,22 +49,32 @@ public class ShelterController {
     @PostMapping
     public ResponseEntity<NearestShelterResponse> getNearestAnyShelter(
             @RequestBody @Valid NearbyShelterRequest request) {
-        return ResponseEntity.ok(shelterService.getNearbyShelter(request));
+        return ResponseEntity.ok(shelterService.getNearestShelter(request));
     }
 
     @Operation(summary = "가까운 대피소 리스트 가져오기", description =
             """
-            위도 경도를 body 에 담아서 post 요청 해주세요.
+           위도(latitude), 경도(longitude), 대피소 유형(shelterType),을 body 에 담아서 post 요청 해주세요.
             
-            가까운 대피소 정보를 거리 순으로 정렬하여 반환합니다.
+            [ I ] shelterType 이 null 이면 대피소 유형에 상관 없이  
+            
+            가장 가까운 대피소 정보를 반환합니다.
+            
+            [ II ] shelterType 이 '민방위' 이면 민방위 대피소를 반환합니다.
+            
+            [ III ]  shelterType 이 '수해' 이면 수해(홍수 등등..) 대피소를 반환합니다.
+            
+            [ IV ] shelterType 이 '지진' 이면 지진 대피소를 반환합니다. 
+            
+            대피소 정보는 거리 순으로 정렬하여 반환합니다.
+            
+            (주의🔥)  대피소가 하나도 없는 경우에는 빈 리스트를 반환합니다.
             
             count 는 대피소 개수이며,
             
             최대 10 개 까지만 반환합니다.
             
             distance 는 미터(m) 단위이며 1500 m 이내 대피소만 검색합니다.
-            
-            검색 결과가 0 개인 경우, NotFound 예외를 터뜨립니다.
                     
             access token 을 헤더에 담아서 요청해주세요.
             """)

--- a/src/main/java/com/numberone/backend/domain/shelter/controller/ShelterController.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/controller/ShelterController.java
@@ -1,11 +1,9 @@
 package com.numberone.backend.domain.shelter.controller;
 
 import com.numberone.backend.domain.shelter.dto.request.NearbyShelterRequest;
-import com.numberone.backend.domain.shelter.dto.response.GetAllSheltersResponse;
+import com.numberone.backend.domain.shelter.dto.response.GetShelterDatabaseUrlResponse;
 import com.numberone.backend.domain.shelter.dto.response.NearbyShelterListResponse;
 import com.numberone.backend.domain.shelter.dto.response.NearestShelterResponse;
-import com.numberone.backend.domain.shelter.dto.response.ShelterMapper;
-import com.numberone.backend.domain.shelter.entity.Shelter;
 import com.numberone.backend.domain.shelter.service.ShelterService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,8 +12,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Tag(name = "shelters", description = "대피소 관련 API")
 @Slf4j
@@ -87,4 +83,23 @@ public class ShelterController {
     }
 
 
+    @Operation(summary = "대피소 정보 온보딩", description =
+                    """
+                    현재 대피소 database 에 저장된 정보를 지역별, 유형 별로 
+                                        
+                    json 형태로 요약한 데이터가 저장된 url 을 가져옵니다.
+                                        
+                    response 로 받은 url 을 통해서 
+                                        
+                    로컬에서 저장할 대피소 정보들을 얻어올 수 있습니다.
+                    
+                    (주의🔥) 발급된 링크는 1 시간 동안만 유효합니다.
+                                        
+                    access token 을 헤더에 담아서 요청해주세요.
+                                        
+                     """)
+    @GetMapping("/init")
+    public ResponseEntity<GetShelterDatabaseUrlResponse> getShelterDatabaseUrl() {
+        return ResponseEntity.ok(shelterService.getShelterDatabaseInitUrl());
+    }
 }

--- a/src/main/java/com/numberone/backend/domain/shelter/controller/ShelterController.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/controller/ShelterController.java
@@ -37,7 +37,7 @@ public class ShelterController {
                     
             """)
     @PostMapping
-    public ResponseEntity<NearestShelterResponse> getNearestShelter(
+    public ResponseEntity<NearestShelterResponse> getNearestAnyShelter(
             @RequestBody @Valid NearbyShelterRequest request) {
         return ResponseEntity.ok(shelterService.getNearbyShelter(request));
     }
@@ -59,7 +59,7 @@ public class ShelterController {
             access token 을 헤더에 담아서 요청해주세요.
             """)
     @PostMapping("/list")
-    public ResponseEntity<NearbyShelterListResponse> getNearbyShelterList(
+    public ResponseEntity<NearbyShelterListResponse> getNearbyAnyShelterList(
             @RequestBody @Valid NearbyShelterRequest request) {
         return ResponseEntity.ok(shelterService.getNearbyShelterList(request));
     }

--- a/src/main/java/com/numberone/backend/domain/shelter/controller/ShelterController.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/controller/ShelterController.java
@@ -86,8 +86,5 @@ public class ShelterController {
         return ResponseEntity.ok(shelterService.getNearbyShelterList(request));
     }
 
-    @GetMapping
-    public ResponseEntity<List<GetAllSheltersResponse>> getAllSheltersInfo() {
-        return ResponseEntity.ok(shelterService.getAllSheltersInfo());
-    }
+
 }

--- a/src/main/java/com/numberone/backend/domain/shelter/controller/ShelterController.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/controller/ShelterController.java
@@ -1,8 +1,11 @@
 package com.numberone.backend.domain.shelter.controller;
 
 import com.numberone.backend.domain.shelter.dto.request.NearbyShelterRequest;
+import com.numberone.backend.domain.shelter.dto.response.GetAllSheltersResponse;
 import com.numberone.backend.domain.shelter.dto.response.NearbyShelterListResponse;
 import com.numberone.backend.domain.shelter.dto.response.NearestShelterResponse;
+import com.numberone.backend.domain.shelter.dto.response.ShelterMapper;
+import com.numberone.backend.domain.shelter.entity.Shelter;
 import com.numberone.backend.domain.shelter.service.ShelterService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,10 +13,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "shelters", description = "대피소 관련 API")
 @Slf4j
@@ -25,27 +27,27 @@ public class ShelterController {
 
     @Operation(summary = "가장 가까운 대피소 정보 하나 가져오기", description =
             """
-            위도(latitude), 경도(longitude), 대피소 유형(shelterType),을 body 에 담아서 post 요청 해주세요.
-            
-            [ I ] shelterType 이 null 이면 대피소 유형에 상관 없이  
-            
-            가장 가까운 대피소 정보를 반환합니다.
-            
-            [ II ] shelterType 이 '민방위' 이면 민방위 대피소를 반환합니다.
-            
-            [ III ]  shelterType 이 '수해' 이면 수해(홍수 등등..) 대피소를 반환합니다.
-            
-            [ IV ] shelterType 이 '지진' 이면 지진 대피소를 반환합니다.
-            
-            (주의🔥) 대피소가 하나도 없는 경우에는 NotFound 예외를 터뜨립니다.
-            
-            distance 는 미터(m) 단위이며 1500 m 이내 대피소만 검색합니다.
-            
-            검색 결과가 0 개인 경우, NotFound 예외를 터뜨립니다.
-            
-            access token 을 헤더에 담아서 요청해주세요.
-                    
-            """)
+                    위도(latitude), 경도(longitude), 대피소 유형(shelterType),을 body 에 담아서 post 요청 해주세요.
+                                
+                    [ I ] shelterType 이 null 이면 대피소 유형에 상관 없이  
+                                
+                    가장 가까운 대피소 정보를 반환합니다.
+                                
+                    [ II ] shelterType 이 '민방위' 이면 민방위 대피소를 반환합니다.
+                                
+                    [ III ]  shelterType 이 '수해' 이면 수해(홍수 등등..) 대피소를 반환합니다.
+                                
+                    [ IV ] shelterType 이 '지진' 이면 지진 대피소를 반환합니다.
+                                
+                    (주의🔥) 대피소가 하나도 없는 경우에는 NotFound 예외를 터뜨립니다.
+                                
+                    distance 는 미터(m) 단위이며 1500 m 이내 대피소만 검색합니다.
+                                
+                    검색 결과가 0 개인 경우, NotFound 예외를 터뜨립니다.
+                                
+                    access token 을 헤더에 담아서 요청해주세요.
+                            
+                    """)
     @PostMapping
     public ResponseEntity<NearestShelterResponse> getNearestAnyShelter(
             @RequestBody @Valid NearbyShelterRequest request) {
@@ -54,33 +56,38 @@ public class ShelterController {
 
     @Operation(summary = "가까운 대피소 리스트 가져오기", description =
             """
-           위도(latitude), 경도(longitude), 대피소 유형(shelterType),을 body 에 담아서 post 요청 해주세요.
-            
-            [ I ] shelterType 이 null 이면 대피소 유형에 상관 없이  
-            
-            가장 가까운 대피소 정보를 반환합니다.
-            
-            [ II ] shelterType 이 '민방위' 이면 민방위 대피소를 반환합니다.
-            
-            [ III ]  shelterType 이 '수해' 이면 수해(홍수 등등..) 대피소를 반환합니다.
-            
-            [ IV ] shelterType 이 '지진' 이면 지진 대피소를 반환합니다. 
-            
-            대피소 정보는 거리 순으로 정렬하여 반환합니다.
-            
-            (주의🔥)  대피소가 하나도 없는 경우에는 빈 리스트를 반환합니다.
-            
-            count 는 대피소 개수이며,
-            
-            최대 10 개 까지만 반환합니다.
-            
-            distance 는 미터(m) 단위이며 1500 m 이내 대피소만 검색합니다.
-                    
-            access token 을 헤더에 담아서 요청해주세요.
-            """)
+                    위도(latitude), 경도(longitude), 대피소 유형(shelterType),을 body 에 담아서 post 요청 해주세요.
+                     
+                     [ I ] shelterType 이 null 이면 대피소 유형에 상관 없이  
+                     
+                     가장 가까운 대피소 정보를 반환합니다.
+                     
+                     [ II ] shelterType 이 '민방위' 이면 민방위 대피소를 반환합니다.
+                     
+                     [ III ]  shelterType 이 '수해' 이면 수해(홍수 등등..) 대피소를 반환합니다.
+                     
+                     [ IV ] shelterType 이 '지진' 이면 지진 대피소를 반환합니다. 
+                     
+                     대피소 정보는 거리 순으로 정렬하여 반환합니다.
+                     
+                     (주의🔥)  대피소가 하나도 없는 경우에는 빈 리스트를 반환합니다.
+                     
+                     count 는 대피소 개수이며,
+                     
+                     최대 10 개 까지만 반환합니다.
+                     
+                     distance 는 미터(m) 단위이며 1500 m 이내 대피소만 검색합니다.
+                             
+                     access token 을 헤더에 담아서 요청해주세요.
+                     """)
     @PostMapping("/list")
     public ResponseEntity<NearbyShelterListResponse> getNearbyAnyShelterList(
             @RequestBody @Valid NearbyShelterRequest request) {
         return ResponseEntity.ok(shelterService.getNearbyShelterList(request));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<GetAllSheltersResponse>> getAllSheltersInfo() {
+        return ResponseEntity.ok(shelterService.getAllSheltersInfo());
     }
 }

--- a/src/main/java/com/numberone/backend/domain/shelter/dto/request/NearbyShelterRequest.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/dto/request/NearbyShelterRequest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
+@ToString
 @Builder
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/numberone/backend/domain/shelter/dto/request/NearbyShelterRequest.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/dto/request/NearbyShelterRequest.java
@@ -1,26 +1,33 @@
 package com.numberone.backend.domain.shelter.dto.request;
 
+import com.numberone.backend.domain.shelter.util.ShelterType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
 import lombok.*;
 
 @ToString
 @Builder
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NearbyShelterRequest {
     @Schema(defaultValue = "126.9723")
     @NotNull(message = "경도 정보는 null 일 수 없습니다.")
     private Double longitude;
+
     @Schema(defaultValue = "37.5559")
     @NotNull(message = "위도 정보는 null 일 수 없습니다.")
     private Double latitude;
 
-    public static NearbyShelterRequest of(Double longitude, Double latitude) {
+    @Schema(defaultValue = "CIVIL_DEFENCE")
+    private String shelterType;
+
+    public static NearbyShelterRequest of(Double longitude, Double latitude, String shelterType) {
         return NearbyShelterRequest.builder()
                 .longitude(longitude)
                 .latitude(latitude)
+                .shelterType(shelterType)
                 .build();
     }
 }

--- a/src/main/java/com/numberone/backend/domain/shelter/dto/response/GetAllSheltersResponse.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/dto/response/GetAllSheltersResponse.java
@@ -1,0 +1,68 @@
+package com.numberone.backend.domain.shelter.dto.response;
+
+import com.numberone.backend.domain.shelter.util.Address;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.*;
+
+import java.util.List;
+
+@ToString
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class GetAllSheltersResponse {
+
+    AddressDetail addressDetail;
+
+    List<ShelterDetail> floods;
+    List<ShelterDetail> civils;
+    List<ShelterDetail> earthquakes;
+
+    public static GetAllSheltersResponse of(
+            AddressDetail address, List<ShelterDetail> floods, List<ShelterDetail> civils, List<ShelterDetail> earthquakes) {
+        return GetAllSheltersResponse.builder()
+                .addressDetail(address)
+                .floods(floods)
+                .civils(civils)
+                .earthquakes(earthquakes)
+                .build();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ShelterDetail {
+        private Long id;
+        private String fullAddress;
+        private String facilityFullName;
+        private Double longitude;
+        private Double latitude;
+
+        @QueryProjection
+        public ShelterDetail(Long id, String fullAddress, String facilityFullName, Double longitude, Double latitude) {
+            this.id = id;
+            this.fullAddress = fullAddress;
+            this.facilityFullName = facilityFullName;
+            this.longitude = longitude;
+            this.latitude = latitude;
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class AddressDetail {
+        private String city;
+        private String district;
+        private String dong;
+
+        @QueryProjection
+        public AddressDetail(String city, String district, String dong) {
+            this.city = city;
+            this.district = district;
+            this.dong = dong;
+        }
+    }
+
+}

--- a/src/main/java/com/numberone/backend/domain/shelter/dto/response/GetShelterDatabaseUrlResponse.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/dto/response/GetShelterDatabaseUrlResponse.java
@@ -1,0 +1,18 @@
+package com.numberone.backend.domain.shelter.dto.response;
+
+import lombok.*;
+
+@ToString
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class GetShelterDatabaseUrlResponse {
+    String link;
+
+    public static GetShelterDatabaseUrlResponse of(String link) {
+        return GetShelterDatabaseUrlResponse.builder()
+                .link(link)
+                .build();
+    }
+}

--- a/src/main/java/com/numberone/backend/domain/shelter/dto/response/NearbyShelterListResponse.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/dto/response/NearbyShelterListResponse.java
@@ -4,6 +4,7 @@ import lombok.*;
 
 import java.util.List;
 
+@ToString
 @Builder
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/numberone/backend/domain/shelter/dto/response/NearbyShelterListResponse.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/dto/response/NearbyShelterListResponse.java
@@ -33,7 +33,8 @@ public class NearbyShelterListResponse {
                         .facilityName(result.getName())
                         .distance(result.getDistance())
                         .longitude(result.getLongitude())
-                        .latitude(result.getLatitude()).build())
+                        .latitude(result.getLatitude())
+                        .build())
                 .toList();
         return NearbyShelterListResponse.builder()
                 .shelterList(shelterList)

--- a/src/main/java/com/numberone/backend/domain/shelter/dto/response/NearestShelterResponse.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/dto/response/NearestShelterResponse.java
@@ -2,6 +2,7 @@ package com.numberone.backend.domain.shelter.dto.response;
 
 import lombok.*;
 
+@ToString
 @Builder
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/numberone/backend/domain/shelter/entity/Shelter.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/entity/Shelter.java
@@ -3,6 +3,7 @@ package com.numberone.backend.domain.shelter.entity;
 import com.numberone.backend.config.basetime.BaseTimeEntity;
 import com.numberone.backend.domain.shelter.util.Address;
 import com.numberone.backend.domain.shelter.util.ShelterStatus;
+import com.numberone.backend.domain.shelter.util.ShelterType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -33,8 +34,9 @@ public class Shelter extends BaseTimeEntity {
     @Embedded
     private Address address;
 
-    @Comment("시설 유형 이름")
-    private String facilityTypeName;
+    @Comment("대피소 유형( CIVIL_DEFENCE: 민방위, FLOOD: 수해, EARTHQUAKE: 지진")
+    @Enumerated(EnumType.STRING)
+    private ShelterType shelterType;
 
     @Comment("시설 이름")
     private String facilityFullName;

--- a/src/main/java/com/numberone/backend/domain/shelter/repository/ShelterRepository.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/repository/ShelterRepository.java
@@ -22,7 +22,7 @@ public interface ShelterRepository extends JpaRepository<Shelter, Long> {
             " ORDER BY distance " +
             " LIMIT 10",
             nativeQuery = true)
-    List<ShelterMapper> findNearbyShelterList(@Param("longitude") double longitude, @Param("latitude") double latitude);
+    List<ShelterMapper> findNearbyAnyShelterList(@Param("longitude") double longitude, @Param("latitude") double latitude);
 
     @Query(value =
             " SELECT shelter.shelter_id AS id, shelter.facility_full_name as name, " +
@@ -35,5 +35,5 @@ public interface ShelterRepository extends JpaRepository<Shelter, Long> {
                     " ORDER BY distance " +
                     " LIMIT 1",
             nativeQuery = true)
-    Optional<ShelterMapper> findNearestShelter(@Param("longitude") double longitude, @Param("latitude") double latitude);
+    Optional<ShelterMapper> findNearestAnyShelter(@Param("longitude") double longitude, @Param("latitude") double latitude);
 }

--- a/src/main/java/com/numberone/backend/domain/shelter/repository/ShelterRepository.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/repository/ShelterRepository.java
@@ -13,14 +13,14 @@ public interface ShelterRepository extends JpaRepository<Shelter, Long> {
 
     @Query(value =
             " SELECT shelter.shelter_id AS id, shelter.facility_full_name as name, " +
-            " ST_DISTANCE_SPHERE(Point(:longitude, :latitude), Point(shelter.longitude, shelter.latitude)) AS distance ," +
-            " shelter.longitude, shelter.latitude " +
-            " FROM shelter " +
-            " WHERE shelter.longitude != 0 and shelter.latitude != 0 " +
-            " AND shelter.status = 'OPEN' " +
-            " HAVING distance <= 1500 " +
-            " ORDER BY distance " +
-            " LIMIT 10",
+                    " ST_DISTANCE_SPHERE(Point(:longitude, :latitude), Point(shelter.longitude, shelter.latitude)) AS distance ," +
+                    " shelter.longitude, shelter.latitude " +
+                    " FROM shelter " +
+                    " WHERE shelter.longitude != 0 and shelter.latitude != 0 " +
+                    " AND shelter.status = 'OPEN' " +
+                    " HAVING distance <= 1500 " +
+                    " ORDER BY distance " +
+                    " LIMIT 10",
             nativeQuery = true)
     List<ShelterMapper> findNearbyAnyShelterList(@Param("longitude") double longitude, @Param("latitude") double latitude);
 
@@ -36,4 +36,31 @@ public interface ShelterRepository extends JpaRepository<Shelter, Long> {
                     " LIMIT 1",
             nativeQuery = true)
     Optional<ShelterMapper> findNearestAnyShelter(@Param("longitude") double longitude, @Param("latitude") double latitude);
+
+    @Query(value =
+            " SELECT shelter.shelter_id AS id, shelter.facility_full_name as name, " +
+                    " ST_DISTANCE_SPHERE(Point(:longitude, :latitude), Point(shelter.longitude, shelter.latitude)) AS distance ," +
+                    " shelter.longitude, shelter.latitude " +
+                    " FROM shelter " +
+                    " WHERE (shelter.longitude != 0 and shelter.latitude != 0) and shelter.shelter_type = :shelter_type " +
+                    " AND shelter.status = 'OPEN' " +
+                    " HAVING distance <= 1500 " +
+                    " ORDER BY distance " +
+                    " LIMIT 10",
+            nativeQuery = true)
+    List<ShelterMapper> findNearbyShelterListByType(@Param("longitude") double longitude, @Param("latitude") double latitude, @Param("shelter_type") String shelterType);
+
+    @Query(value =
+            " SELECT shelter.shelter_id AS id, shelter.facility_full_name as name, " +
+                    " ST_DISTANCE_SPHERE(Point(:longitude, :latitude), Point(shelter.longitude, shelter.latitude)) AS distance ," +
+                    " shelter.longitude, shelter.latitude " +
+                    " FROM shelter " +
+                    " WHERE shelter.longitude != 0 and shelter.latitude != 0 and shelter.shelter_type = :shelter_type " +
+                    " AND shelter.status = 'OPEN' " +
+                    " HAVING distance <= 1500 " +
+                    " ORDER BY distance " +
+                    " LIMIT 1",
+            nativeQuery = true)
+    Optional<ShelterMapper> findNearestShelterByType(@Param("longitude") double longitude, @Param("latitude") double latitude, @Param("shelter_type") String shelterType);
+
 }

--- a/src/main/java/com/numberone/backend/domain/shelter/repository/ShelterRepository.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/repository/ShelterRepository.java
@@ -2,6 +2,7 @@ package com.numberone.backend.domain.shelter.repository;
 
 import com.numberone.backend.domain.shelter.dto.response.ShelterMapper;
 import com.numberone.backend.domain.shelter.entity.Shelter;
+import com.numberone.backend.domain.shelter.repository.custom.CustomShelterRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-public interface ShelterRepository extends JpaRepository<Shelter, Long> {
+public interface ShelterRepository extends JpaRepository<Shelter, Long>, CustomShelterRepository {
 
     @Query(value =
             " SELECT shelter.shelter_id AS id, shelter.facility_full_name as name, " +

--- a/src/main/java/com/numberone/backend/domain/shelter/repository/custom/CustomShelterRepository.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/repository/custom/CustomShelterRepository.java
@@ -1,0 +1,10 @@
+package com.numberone.backend.domain.shelter.repository.custom;
+
+import com.numberone.backend.domain.shelter.dto.response.GetAllSheltersResponse;
+
+import java.util.List;
+
+public interface CustomShelterRepository {
+
+    List<GetAllSheltersResponse> findAllSheltersGroupByRegions();
+}

--- a/src/main/java/com/numberone/backend/domain/shelter/repository/custom/CustomShelterRepositoryImpl.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/repository/custom/CustomShelterRepositoryImpl.java
@@ -1,0 +1,71 @@
+package com.numberone.backend.domain.shelter.repository.custom;
+
+import com.numberone.backend.domain.shelter.dto.response.GetAllSheltersResponse;
+import com.numberone.backend.domain.shelter.dto.response.QGetAllSheltersResponse_AddressDetail;
+import com.numberone.backend.domain.shelter.dto.response.QGetAllSheltersResponse_ShelterDetail;
+import com.numberone.backend.domain.shelter.util.Address;
+import com.numberone.backend.domain.shelter.util.ShelterStatus;
+import com.numberone.backend.domain.shelter.util.ShelterType;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.numberone.backend.domain.shelter.entity.QShelter.shelter;
+
+
+public class CustomShelterRepositoryImpl implements CustomShelterRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public CustomShelterRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<GetAllSheltersResponse> findAllSheltersGroupByRegions() {
+        List<GetAllSheltersResponse> result = new ArrayList<>();
+
+        List<GetAllSheltersResponse.AddressDetail> addressList = queryFactory.select(
+                        new QGetAllSheltersResponse_AddressDetail(shelter.address.city, shelter.address.district, shelter.address.dong)
+                )
+                .distinct()
+                .from(shelter)
+                .fetch();
+
+        for (GetAllSheltersResponse.AddressDetail address : addressList) {
+            List<GetAllSheltersResponse.ShelterDetail> floods = findSheltersByAddressAndType(address, ShelterType.FLOOD);
+            List<GetAllSheltersResponse.ShelterDetail> civils = findSheltersByAddressAndType(address, ShelterType.CIVIL_DEFENCE);
+            List<GetAllSheltersResponse.ShelterDetail> earthquakes = findSheltersByAddressAndType(address, ShelterType.EARTHQUAKE);
+
+            result.add(GetAllSheltersResponse.of(address, floods, civils, earthquakes));
+
+        }
+        return result;
+    }
+
+    public List<GetAllSheltersResponse.ShelterDetail> findSheltersByAddressAndType(GetAllSheltersResponse.AddressDetail address, ShelterType type) {
+        return queryFactory.select(new QGetAllSheltersResponse_ShelterDetail(
+                        shelter.id,
+                        shelter.address.fullAddress,
+                        shelter.facilityFullName,
+                        shelter.address.longitude,
+                        shelter.address.latitude
+                ))
+                .from(shelter)
+                .where(shelter.address.city.isNotNull()
+                        .and(shelter.address.city.eq(address.getCity()))
+                        .and(shelter.address.district.isNotNull())
+                        .and(shelter.address.district.eq(address.getDistrict()))
+                        .and(shelter.address.dong.isNotNull())
+                        .and(shelter.address.dong.eq(address.getDong()))
+                        .and(shelter.shelterType.eq(type))
+                        .and(shelter.status.eq(ShelterStatus.OPEN))
+                ).groupBy(
+                        shelter.address.city,
+                        shelter.address.district,
+                        shelter.address.dong)
+                .fetch();
+    }
+}

--- a/src/main/java/com/numberone/backend/domain/shelter/repository/custom/CustomShelterRepositoryImpl.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/repository/custom/CustomShelterRepositoryImpl.java
@@ -65,10 +65,7 @@ public class CustomShelterRepositoryImpl implements CustomShelterRepository {
                         .and(shelter.address.dong.eq(dong))
                         .and(shelter.shelterType.eq(type))
                         .and(shelter.status.eq(ShelterStatus.OPEN))
-                ).groupBy(
-                        shelter.address.city,
-                        shelter.address.district,
-                        shelter.address.dong)
+                )
                 .fetch();
     }
 

--- a/src/main/java/com/numberone/backend/domain/shelter/service/ShelterService.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/service/ShelterService.java
@@ -21,13 +21,13 @@ public class ShelterService {
     private final ShelterRepository shelterRepository;
 
     public NearestShelterResponse getNearbyShelter(NearbyShelterRequest request) {
-        ShelterMapper result = shelterRepository.findNearestShelter(request.getLongitude(), request.getLatitude())
+        ShelterMapper result = shelterRepository.findNearestAnyShelter(request.getLongitude(), request.getLatitude())
                 .orElseThrow(NotFoundShelterException::new);
         return NearestShelterResponse.of(result);
     }
 
     public NearbyShelterListResponse getNearbyShelterList(NearbyShelterRequest request) {
-        List<ShelterMapper> shelters = shelterRepository.findNearbyShelterList(request.getLongitude(), request.getLatitude());
+        List<ShelterMapper> shelters = shelterRepository.findNearbyAnyShelterList(request.getLongitude(), request.getLatitude());
         if (shelters.isEmpty()) {
             throw new NotFoundShelterException();
         }

--- a/src/main/java/com/numberone/backend/domain/shelter/service/ShelterService.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/service/ShelterService.java
@@ -1,6 +1,7 @@
 package com.numberone.backend.domain.shelter.service;
 
 import com.numberone.backend.domain.shelter.dto.request.NearbyShelterRequest;
+import com.numberone.backend.domain.shelter.dto.response.GetAllSheltersResponse;
 import com.numberone.backend.domain.shelter.dto.response.NearbyShelterListResponse;
 import com.numberone.backend.domain.shelter.dto.response.NearestShelterResponse;
 import com.numberone.backend.domain.shelter.dto.response.ShelterMapper;
@@ -57,5 +58,10 @@ public class ShelterService {
         /* type 이 null 이면 type(대피소 유형 별) 에 상관없이 쿼리 결과를 반환합니다. */
         result = shelterRepository.findNearbyAnyShelterList(request.getLongitude(), request.getLatitude());
         return NearbyShelterListResponse.of(result);
+    }
+
+    public List<GetAllSheltersResponse> getAllSheltersInfo() {
+        return shelterRepository.findAllSheltersGroupByRegions();
+
     }
 }

--- a/src/main/java/com/numberone/backend/domain/shelter/service/ShelterService.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/service/ShelterService.java
@@ -1,15 +1,14 @@
 package com.numberone.backend.domain.shelter.service;
 
 import com.numberone.backend.domain.shelter.dto.request.NearbyShelterRequest;
-import com.numberone.backend.domain.shelter.dto.response.GetAllSheltersResponse;
-import com.numberone.backend.domain.shelter.dto.response.NearbyShelterListResponse;
-import com.numberone.backend.domain.shelter.dto.response.NearestShelterResponse;
-import com.numberone.backend.domain.shelter.dto.response.ShelterMapper;
+import com.numberone.backend.domain.shelter.dto.response.*;
 import com.numberone.backend.domain.shelter.repository.ShelterRepository;
 import com.numberone.backend.domain.shelter.util.ShelterType;
 import com.numberone.backend.exception.notfound.NotFoundShelterException;
+import com.numberone.backend.support.S3Provider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +22,11 @@ import java.util.Objects;
 public class ShelterService {
 
     private final ShelterRepository shelterRepository;
+
+    private final S3Provider s3Provider;
+
+    @Value("${storage-path.shelter-database-init-path}")
+    private String databaseUploadPath;
 
     public NearestShelterResponse getNearestShelter(NearbyShelterRequest request) {
 
@@ -58,5 +62,9 @@ public class ShelterService {
         /* type 이 null 이면 type(대피소 유형 별) 에 상관없이 쿼리 결과를 반환합니다. */
         result = shelterRepository.findNearbyAnyShelterList(request.getLongitude(), request.getLatitude());
         return NearbyShelterListResponse.of(result);
+    }
+
+    public GetShelterDatabaseUrlResponse getShelterDatabaseInitUrl(){
+        return GetShelterDatabaseUrlResponse.of(s3Provider.getS3FileUrl(databaseUploadPath));
     }
 }

--- a/src/main/java/com/numberone/backend/domain/shelter/service/ShelterService.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/service/ShelterService.java
@@ -5,6 +5,7 @@ import com.numberone.backend.domain.shelter.dto.response.NearbyShelterListRespon
 import com.numberone.backend.domain.shelter.dto.response.NearestShelterResponse;
 import com.numberone.backend.domain.shelter.dto.response.ShelterMapper;
 import com.numberone.backend.domain.shelter.repository.ShelterRepository;
+import com.numberone.backend.domain.shelter.util.ShelterType;
 import com.numberone.backend.exception.notfound.NotFoundShelterException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,25 +13,49 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
 public class ShelterService {
+
     private final ShelterRepository shelterRepository;
 
-    public NearestShelterResponse getNearbyShelter(NearbyShelterRequest request) {
-        ShelterMapper result = shelterRepository.findNearestAnyShelter(request.getLongitude(), request.getLatitude())
+    public NearestShelterResponse getNearestShelter(NearbyShelterRequest request) {
+
+        ShelterMapper result;
+        if (!Objects.isNull(request.getShelterType())) {
+            /* type 이 존재하면 type(대피소 유형 별) 에 따른 쿼리 결과를 반환합니다. */
+            result = shelterRepository.findNearestShelterByType(
+                            request.getLongitude(),
+                            request.getLatitude(),
+                            ShelterType.kor2code(request.getShelterType()).toString())
+                    .orElseThrow(NotFoundShelterException::new);
+            return NearestShelterResponse.of(result);
+        }
+
+        /* type 이 null 이면 type(대피소 유형 별) 에 상관없이 쿼리 결과를 반환합니다. */
+        result = shelterRepository.findNearestAnyShelter(request.getLongitude(), request.getLatitude())
                 .orElseThrow(NotFoundShelterException::new);
         return NearestShelterResponse.of(result);
     }
 
     public NearbyShelterListResponse getNearbyShelterList(NearbyShelterRequest request) {
-        List<ShelterMapper> shelters = shelterRepository.findNearbyAnyShelterList(request.getLongitude(), request.getLatitude());
-        if (shelters.isEmpty()) {
-            throw new NotFoundShelterException();
+
+        List<ShelterMapper> result;
+        if (!Objects.isNull(request.getShelterType())) {
+            /* type 이 존재하면 type(대피소 유형 별) 에 따른 쿼리 결과를 반환합니다. */
+            result = shelterRepository.findNearbyShelterListByType(
+                    request.getLongitude(),
+                    request.getLatitude(),
+                    ShelterType.kor2code(request.getShelterType()).toString());
+            return NearbyShelterListResponse.of(result);
         }
-        return NearbyShelterListResponse.of(shelters);
+
+        /* type 이 null 이면 type(대피소 유형 별) 에 상관없이 쿼리 결과를 반환합니다. */
+        result = shelterRepository.findNearbyAnyShelterList(request.getLongitude(), request.getLatitude());
+        return NearbyShelterListResponse.of(result);
     }
 }

--- a/src/main/java/com/numberone/backend/domain/shelter/service/ShelterService.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/service/ShelterService.java
@@ -59,9 +59,4 @@ public class ShelterService {
         result = shelterRepository.findNearbyAnyShelterList(request.getLongitude(), request.getLatitude());
         return NearbyShelterListResponse.of(result);
     }
-
-    public List<GetAllSheltersResponse> getAllSheltersInfo() {
-        return shelterRepository.findAllSheltersGroupByRegions();
-
-    }
 }

--- a/src/main/java/com/numberone/backend/domain/shelter/util/Address.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/util/Address.java
@@ -12,6 +12,15 @@ public class Address {
     @Comment("(구) 주소")
     private String fullAddress;
 
+    @Comment("행정시")
+    private String city;
+
+    @Comment("행정구")
+    private String district;
+
+    @Comment("행정동(읍/면)")
+    private String dong;
+
     @Comment("도로명 주소")
     private String roadNameAddress;
 
@@ -20,6 +29,7 @@ public class Address {
 
     @Comment("EPSG:2097 좌표 정보(x)")
     private Double coordinateX;
+
     @Comment("EPSG:2097 좌표 정보(y)")
     private Double coordinateY;
 

--- a/src/main/java/com/numberone/backend/domain/shelter/util/ShelterType.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/util/ShelterType.java
@@ -1,0 +1,11 @@
+package com.numberone.backend.domain.shelter.util;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ShelterType {
+    CIVIL_DEFENCE,
+    FLOOD,
+    EARTHQUAKE;
+    String value;
+}

--- a/src/main/java/com/numberone/backend/domain/shelter/util/ShelterType.java
+++ b/src/main/java/com/numberone/backend/domain/shelter/util/ShelterType.java
@@ -1,5 +1,6 @@
 package com.numberone.backend.domain.shelter.util;
 
+import com.numberone.backend.exception.badrequest.InvalidShelterTypeException;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -7,5 +8,21 @@ public enum ShelterType {
     CIVIL_DEFENCE,
     FLOOD,
     EARTHQUAKE;
-    String value;
+
+    String code;
+
+    public static ShelterType kor2code(String kor) {
+        switch (kor) {
+            case "수해" -> {
+                return FLOOD;
+            }
+            case "지진" -> {
+                return EARTHQUAKE;
+            }
+            case "민방위" -> {
+                return CIVIL_DEFENCE;
+            }
+        }
+        throw new InvalidShelterTypeException();
+    }
 }

--- a/src/main/java/com/numberone/backend/exception/badrequest/InvalidShelterTypeException.java
+++ b/src/main/java/com/numberone/backend/exception/badrequest/InvalidShelterTypeException.java
@@ -1,0 +1,9 @@
+package com.numberone.backend.exception.badrequest;
+
+import static com.numberone.backend.exception.context.CustomExceptionContext.INVALID_SHELTER_TYPE;
+
+public class InvalidShelterTypeException extends BadRequestException {
+    public InvalidShelterTypeException() {
+        super(INVALID_SHELTER_TYPE);
+    }
+}

--- a/src/main/java/com/numberone/backend/exception/context/CustomExceptionContext.java
+++ b/src/main/java/com/numberone/backend/exception/context/CustomExceptionContext.java
@@ -17,6 +17,7 @@ public enum CustomExceptionContext implements ExceptionContext {
 
     // SHELTER 관련 예외
     NOT_FOUND_SHELTER("주변에 가까운 대피소가 존재하지 않습니다.", 3000),
+    INVALID_SHELTER_TYPE("올바른 대피소 유형을 입력해주세요. (민방위, 수해, 지진) ", 3001),
 
     // S3 관련 예외
     S3_FILE_UPLOAD_FAILED("S3 파일 업로드에 실패했습니다.", 4000),

--- a/src/main/java/com/numberone/backend/support/S3Provider.java
+++ b/src/main/java/com/numberone/backend/support/S3Provider.java
@@ -8,6 +8,7 @@ import com.numberone.backend.exception.badrequest.FileMissingException;
 import com.numberone.backend.exception.badrequest.FileUploadException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.entity.ContentType;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -52,6 +53,16 @@ public class S3Provider {
             throw new FileUploadException();
         }
         return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    public String uploadJsonFile(String originName, InputStream inputStream) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(ContentType.APPLICATION_JSON.toString());
+
+        amazonS3Client.putObject(new PutObjectRequest(bucket, originName, inputStream, objectMetadata)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+
+        return amazonS3Client.getUrl(bucket, originName).toString();
     }
 
     private void checkInvalidUploadFile(MultipartFile multipartFile) {

--- a/src/main/java/com/numberone/backend/support/S3Provider.java
+++ b/src/main/java/com/numberone/backend/support/S3Provider.java
@@ -1,7 +1,9 @@
 package com.numberone.backend.support;
 
+import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.numberone.backend.exception.badrequest.FileMissingException;
@@ -71,4 +73,16 @@ public class S3Provider {
         }
     }
 
+    public String getS3FileUrl(String fileName) {
+        java.util.Date expiration = new java.util.Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += 1000 * 60 * 60; /* 해당 링크는 1 시간 동안만 유효 합니다. */
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucket, fileName)
+                        .withMethod(HttpMethod.GET)
+                        .withExpiration(new java.util.Date(expTimeMillis));
+
+        return amazonS3Client.generatePresignedUrl(generatePresignedUrlRequest).toString();
+    }
 }

--- a/src/main/java/com/numberone/backend/support/logging/LogAspect.java
+++ b/src/main/java/com/numberone/backend/support/logging/LogAspect.java
@@ -1,0 +1,48 @@
+package com.numberone.backend.support.logging;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+@Component
+@Aspect
+@Slf4j
+public class LogAspect {
+
+    @Pointcut("execution(* com.numberone.backend.domain..*Controller.*(..))")
+    public void controller() {
+    }
+
+    @Pointcut("execution(* com.numberone.backend.domain..*Service.*(..))")
+    public void service() {
+    }
+
+    @Before("controller()")
+    public void beforeRequest(JoinPoint joinPoint) {
+        log.info(" Start request ---> {} ", joinPoint.getSignature().toShortString());
+        Arrays.stream(joinPoint.getArgs())
+                .map(Object::toString)
+                .map(str -> "\t" + str)
+                .forEach(log::info);
+    }
+
+    @AfterReturning(pointcut = "controller()", returning = "returnValue")
+    public void afterReturningLogging(JoinPoint joinPoint, Object returnValue) {
+        log.info(" End request ---> {} ", joinPoint.getSignature().toShortString());
+
+        if (Objects.isNull(returnValue)) return;
+
+        log.info("\t response info: {}", returnValue.toString());
+    }
+
+    @AfterThrowing(pointcut = "controller()", throwing = "e")
+    public void afterThrowingLogging(JoinPoint joinPoint, Exception e) {
+        log.error("###Occured error in request {}", joinPoint.getSignature().toShortString());
+        log.error("\t{}", e.getMessage());
+    }
+
+}


### PR DESCRIPTION
- Closes #33 #40 

## 대피소 데이터 추가 (총 45,877개)
- 민방위 대피소 데이터 41,002 개
- 수해 대피소 데이터 872 개 

공공 데이터 포털에 존재하는 모든 데이터를 가져옴.. (해당 사이트에 업로드되지 않은 지역은 없음..😥)
```
--- 이번에 추가한 데이터 파일명 ---

강원도 홍천군_수해대피소_20230518.csv
경기도 동두천시_수해대피소_20230526.csv
경기도 평택시_수해대피소_20230522.csv
경상남도 진주시_수해대피소현황_20230525.csv
경상북도 영양군_수해대피소_20230526.csv
서울시 수해대피소 공간정보.csv
전라북도 고창군_수해대피소_20230430.CSV
전라북도 남원시_수해대피소_20230522.csv
충청북도 진천군_수해대피소 데이터_20230517.csv

대전광역시_지진 옥외대피장소 현황_20210804.csv
서울시 지진대피소 현황.csv
서울시 지진옥외대피소.csv
세종특별자치시_지진옥외대피소_20230904.csv
인천광역시 미추홀구_지진옥외대피소 목록_20230726.csv
인천광역시_지진옥외대피소 사물주소 현황_20230111.csv
제주특별자치도 서귀포시_지진옥외대피장소 사물주소현황_20231010.csv
```

- 지진 대피소 데이터 4,002 개
- 대피소 스키마 변경 작업
  - 대피소 유형, 행정시, 행정동(읍/면/리), 행정구 컬럼 추가

```MYSQL
-- auto-generated definition
create table shelter
(
    shelter_id            bigint auto_increment
        primary key,
    created_at            datetime(6)                                   null comment '최초 생성 시각',
    modified_at           datetime(6)                                   null comment '마지막 수정 시각',
    city                  varchar(255)                                  null comment '행정시',
    coordinatex           double                                        null comment 'EPSG:2097 좌표 정보(x)',
    coordinatey           double                                        null comment 'EPSG:2097 좌표 정보(y)',
    district              varchar(255)                                  null comment '행정구',
    dong                  varchar(255)                                  null comment '행정동(읍/면)',
    full_address          varchar(255)                                  null comment '(구) 주소',
    latitude              double                                        null comment '위도',
    longitude             double                                        null comment '경도',
    road_name_address     varchar(255)                                  null comment '도로명 주소',
    road_name_postal_code varchar(255)                                  null comment '도로명 우편번호',
    district_code         varchar(255)                                  null comment '관리 코드(행정용)',
    facility_full_name    varchar(255)                                  null comment '시설 이름',
    management_number     varchar(255)                                  null comment '관리 번호(행정용)',
    shelter_type          enum ('CIVIL_DEFENCE', 'EARTHQUAKE', 'FLOOD') null comment '대피소 유형( CIVIL_DEFENCE: 민방위, FLOOD: 수해, EARTHQUAKE: 지진',
    status                enum ('CLOSE', 'OPEN')                        null comment '대피소 운영 상태(OPEN/CLOSE)',
    facility_type_name    varchar(255)                                  null comment '시설 유형 이름'
)
    comment '대피소 정보';


```

## 대피소 api 변경
- `api/shelters` 와  `api/shelters/list`
  -  requestBody 에 `shelterType` 필드를 포함하여 보내면, 해당 대피소 유형(`민방위`, `수해`, `지진`)에 따른 쿼리 결과를 반환합니다.
  - `shelterType` 를 포함하여 보내지 않으면, 대피소 유형에 상관없이 거리순으로 조회합니다.
  - `shelterType` 를 포함하여 보냈으나, 잘못된 요청이면 예외를 터뜨립니다.

## 대피소 json 데이터 업로드/조회 API 구현
- json 데이터 생성 및 업로드: `GET api/admin/shelter-init` 
  -  현재 대피소 db 내 존재하는 데이터를 기반으로, 지역 별, 대피소 유형 별 대피소 정보 `전체` 를 json 형태로 저장한 뒤 s3 storage 에 업로드합니다.

- 업로드 된 json 데이터 조회 `GET api/shelters/init`
  -  저장한 데이터를 조회할 수 있는 link 를 반환합니다. ( 해당 링크는 1 시간 동안만 유효하도록 설정함)

## 로깅 AOP 작업
- 모든 controller 에 대하여, 요청 시점, 응답 시점에 log 를 남기도록 구현하였습니다.
  - 현재는 API 통신에 민감정보를 사용하지 않아 문제 없지만, 추후 request/response 과정에서 민감한 정보(유저 비밀번호 등)를 통신하는 경우 별도의 마스킹 작업이 필요합니다.


