### PR TITLE
Chore(#44) : 배포 타겟 브랜치 정리

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,13 +4,7 @@ name: NumberOne-Backend-CICD
 # event trigger
 on:
   push:
-    branches:
-      - main
-      - 'dev-check'
-  pull_request:
-    branches:
-      - main
-      - 'dev'
+    branches: [ "main", "dev", "dev-check"]
 
 permissions: write-all
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -6,11 +6,11 @@ on:
   push:
     branches:
       - main
-      - 'fix/*'
+      - 'dev-check'
   pull_request:
     branches:
       - main
-      - 'fix/*'
+      - 'dev'
 
 permissions: write-all
 


### PR DESCRIPTION
- Close #44 

- main , dev, dev-check 에 PUSH 시 cicd.yml 스크립트 실행됨
  - 급하게 배포해야할 브랜치가 있다면, dev-check 에 `merge --no-ff` 하여 push 해서 동작 확인하기.
  - 동작 이상 없을 시, dev 에 pull request
  - `main` - `dev` 는 주기적으로 싱크 맞추기
  - `dev` - `dev-check` 도 주기적으로 싱크 맞추기

- 브랜치 새로 만들 시, 반드시 dev 에서 만들기.
- `main` 은 추후 운영서버 분리하는 경우를 위해.. 
 