### PR TITLE
Feat: 커뮤니티 관련 API 요구사항 반영

### DIFF
--- a/src/main/java/com/numberone/backend/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/numberone/backend/domain/article/controller/ArticleController.java
@@ -34,16 +34,16 @@ public class ArticleController {
                         
             1. title 은 글 제목 입니다 (not null)
             2. content 는 글 내용 입니다 (not null)
-            3. articleTag 는 게시글 태그 입니다. LIFE(일상), FRAUD(사기), SAFETY(안전), REPORT(제보)
+            3. articleTag 는 게시글 태그 입니다. LIFE(일상), TRAFFIC(교통), SAFETY(치안), NONE(기타) -> 영어로 보내주세요
             4. imageList 는 이미지 (MultiPart) 리스트 입니다.
-            5. thumbNailImageIdx 는 썸네일 이미지의 인덱스 입니다. (0,1,2, ...
+            5. imageList 의 첫 원소를 썸네일로 지정합니다.
             imageList 에 이미지를 담아서 보내는 경우,
             idx 에 따라서 썸네일 이미지를 결정합니다.
                         
             """)
 
     @PostMapping
-    public ResponseEntity<UploadArticleResponse> uploadArticle(@RequestBody @Valid UploadArticleRequest request) {
+    public ResponseEntity<UploadArticleResponse> uploadArticle(@ModelAttribute @Valid UploadArticleRequest request) {
         return ResponseEntity.created(URI.create("/api/articles"))
                 .body(articleService.uploadArticle(request));
     }

--- a/src/main/java/com/numberone/backend/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/numberone/backend/domain/article/controller/ArticleController.java
@@ -87,7 +87,7 @@ public class ArticleController {
     @GetMapping
     public ResponseEntity<Slice<GetArticleListResponse>> getArticlePages(
             Pageable pageable,
-            @ModelAttribute ArticleSearchParameter param) { // todo: 해당 유저가 좋아요를 눌렀는지 여부까지 표시되도록 수정
+            @ModelAttribute ArticleSearchParameter param) {
         return ResponseEntity.ok(articleService.getArticleListPaging(param, pageable));
     }
 

--- a/src/main/java/com/numberone/backend/domain/article/dto/request/UploadArticleRequest.java
+++ b/src/main/java/com/numberone/backend/domain/article/dto/request/UploadArticleRequest.java
@@ -30,7 +30,6 @@ public class UploadArticleRequest {
 
     // 이미지 관련
     private List<MultipartFile> imageList; // 이미지 리스트
-    private Long thumbNailImageIdx; // 썸네일 이미지의 순서 (0,1,2,...)
 
     private Double longitude;
     private Double latitude;

--- a/src/main/java/com/numberone/backend/domain/article/dto/response/GetArticleDetailResponse.java
+++ b/src/main/java/com/numberone/backend/domain/article/dto/response/GetArticleDetailResponse.java
@@ -1,6 +1,8 @@
 package com.numberone.backend.domain.article.dto.response;
 
 import com.numberone.backend.domain.article.entity.Article;
+import com.numberone.backend.domain.article.entity.ArticleStatus;
+import com.numberone.backend.domain.article.entity.ArticleTag;
 import com.numberone.backend.domain.member.entity.Member;
 import lombok.*;
 
@@ -22,18 +24,26 @@ public class GetArticleDetailResponse {
     private LocalDateTime modifiedAt;
     private String title;
     private String content;
+    private boolean isLiked;
+    private ArticleTag articleTag;
 
     // 작성자 관련
-    private String memberName;
-    private String memberNickName;
-    private String address; // todo: 더미 데이터
+    private String ownerName;
+    private String ownerNickName;
+    private String address;
     private Long ownerMemberId;
+    private String ownerProfileImageUrl;
 
     // 이미지 관련
     private List<String> imageUrls;
     private String thumbNailImageUrl;
 
-    public static GetArticleDetailResponse of(Article article, List<String> imageUrls, String thumbNailImageUrl, Member member){
+    public static GetArticleDetailResponse of(
+            Article article,
+            List<String> imageUrls,
+            String thumbNailImageUrl,
+            Member owner,
+            List<Long> memberLikedArticleList) {
         return GetArticleDetailResponse.builder()
                 .articleId(article.getId())
                 .title(article.getTitle())
@@ -45,13 +55,17 @@ public class GetArticleDetailResponse {
                 )
                 .createdAt(article.getCreatedAt())
                 .modifiedAt(article.getModifiedAt())
-                .ownerMemberId(member.getId())
-                .memberName(member.getRealName())
-                .memberNickName(member.getNickName())
+                .ownerMemberId(owner.getId())
+                .ownerName(owner.getRealName())
+                .ownerNickName(owner.getNickName())
                 .imageUrls(imageUrls)
                 .thumbNailImageUrl(thumbNailImageUrl)
-                .address("서울시 광진구 자양동") // 교체
+                .address(article.getAddress())
+                .ownerProfileImageUrl(owner.getProfileImageUrl())
+                .isLiked(memberLikedArticleList.contains(article.getId()))
+                .articleTag(article.getArticleTag())
                 .build();
     }
+
 
 }

--- a/src/main/java/com/numberone/backend/domain/article/dto/response/GetArticleDetailResponse.java
+++ b/src/main/java/com/numberone/backend/domain/article/dto/response/GetArticleDetailResponse.java
@@ -26,6 +26,7 @@ public class GetArticleDetailResponse {
     private String content;
     private boolean isLiked;
     private ArticleTag articleTag;
+    private Long commentCount;
 
     // 작성자 관련
     private String ownerName;
@@ -43,7 +44,8 @@ public class GetArticleDetailResponse {
             List<String> imageUrls,
             String thumbNailImageUrl,
             Member owner,
-            List<Long> memberLikedArticleList) {
+            List<Long> memberLikedArticleList,
+            Long commentCount ) {
         return GetArticleDetailResponse.builder()
                 .articleId(article.getId())
                 .title(article.getTitle())
@@ -64,8 +66,8 @@ public class GetArticleDetailResponse {
                 .ownerProfileImageUrl(owner.getProfileImageUrl())
                 .isLiked(memberLikedArticleList.contains(article.getId()))
                 .articleTag(article.getArticleTag())
+                .commentCount(commentCount)
                 .build();
     }
-
 
 }

--- a/src/main/java/com/numberone/backend/domain/article/dto/response/GetArticleListResponse.java
+++ b/src/main/java/com/numberone/backend/domain/article/dto/response/GetArticleListResponse.java
@@ -9,6 +9,7 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @ToString
@@ -32,6 +33,7 @@ public class GetArticleListResponse {
 
     private Integer articleLikeCount;
     private Integer commentCount;
+    private Boolean isLiked;
 
 
     @QueryProjection
@@ -57,7 +59,7 @@ public class GetArticleListResponse {
         this.thumbNailImageUrl = thumbNailImageUrl;
     }
 
-    public void updateInfo(Optional<Member> owner, Optional<ArticleImage> articleImage){
+    public void updateInfo(Optional<Member> owner, Optional<ArticleImage> articleImage, List<Long> memberLikedArticleIdList){
         owner.ifPresentOrElse(
                 o -> setOwnerNickName(o.getNickName()),
                 () -> setOwnerNickName("알 수 없는 사용자")
@@ -66,7 +68,7 @@ public class GetArticleListResponse {
                 image -> setThumbNailImageUrl(image.getImageUrl()),
                 () -> setThumbNailImageUrl("")
         );
+        this.isLiked = memberLikedArticleIdList.contains(id);
     }
-
 
 }

--- a/src/main/java/com/numberone/backend/domain/article/dto/response/GetArticleListResponse.java
+++ b/src/main/java/com/numberone/backend/domain/article/dto/response/GetArticleListResponse.java
@@ -32,7 +32,7 @@ public class GetArticleListResponse {
     private Long thumbNailImageId;
 
     private Integer articleLikeCount;
-    private Integer commentCount;
+    private Long commentCount;
     private Boolean isLiked;
 
 
@@ -48,7 +48,6 @@ public class GetArticleListResponse {
         this.articleStatus = article.getArticleStatus();
         this.thumbNailImageId = thumbNailImageId;
         this.articleLikeCount = article.getLikeCount();
-        this.commentCount = article.getCommentCount();
     }
 
     public void setOwnerNickName(String nickName){
@@ -59,7 +58,14 @@ public class GetArticleListResponse {
         this.thumbNailImageUrl = thumbNailImageUrl;
     }
 
-    public void updateInfo(Optional<Member> owner, Optional<ArticleImage> articleImage, List<Long> memberLikedArticleIdList){
+    public void setCommentCount(Long commentCount){
+        this.commentCount = commentCount;
+    }
+
+    public void updateInfo(Optional<Member> owner,
+                           Optional<ArticleImage> articleImage,
+                           List<Long> memberLikedArticleIdList,
+                           Long commentCount ){
         owner.ifPresentOrElse(
                 o -> setOwnerNickName(o.getNickName()),
                 () -> setOwnerNickName("알 수 없는 사용자")
@@ -69,6 +75,7 @@ public class GetArticleListResponse {
                 () -> setThumbNailImageUrl("")
         );
         this.isLiked = memberLikedArticleIdList.contains(id);
+        this.commentCount = commentCount;
     }
 
 }

--- a/src/main/java/com/numberone/backend/domain/article/dto/response/ModifyArticleResponse.java
+++ b/src/main/java/com/numberone/backend/domain/article/dto/response/ModifyArticleResponse.java
@@ -25,7 +25,7 @@ public class ModifyArticleResponse {
     private String thumbNailImageUrl;
 
     // 작성자 주소
-    private String address; // todo: 더미 데이터
+    private String address;
 
     public static ModifyArticleResponse of(Article article, List<String> imageUrls, String thumbNailImageUrl){
         return ModifyArticleResponse.builder()
@@ -34,7 +34,7 @@ public class ModifyArticleResponse {
                 .modifiedAt(article.getModifiedAt())
                 .imageUrls(imageUrls)
                 .thumbNailImageUrl(thumbNailImageUrl)
-                .address("서울시 광진구 자양동")
+                .address(article.getAddress())
                 .build();
     }
 

--- a/src/main/java/com/numberone/backend/domain/article/dto/response/UploadArticleResponse.java
+++ b/src/main/java/com/numberone/backend/domain/article/dto/response/UploadArticleResponse.java
@@ -21,7 +21,7 @@ public class UploadArticleResponse {
     private String thumbNailImageUrl;
 
     // 작성자 주소
-    private String address; // todo: 더미 데이터
+    private String address;
 
     public static UploadArticleResponse of(Article article, List<String> imageUrls, String thumbNailImageUrl){
         return UploadArticleResponse.builder()

--- a/src/main/java/com/numberone/backend/domain/article/entity/Article.java
+++ b/src/main/java/com/numberone/backend/domain/article/entity/Article.java
@@ -58,10 +58,6 @@ public class Article extends BaseTimeEntity {
     @Comment("게시글 좋아요 개수")
     private Integer likeCount;
 
-    @ColumnDefault("0")
-    @Comment("게시글에 달린 댓글 개수")
-    private Integer commentCount;
-
     @Comment("작성자 ID")
     private Long articleOwnerId;
 
@@ -71,7 +67,6 @@ public class Article extends BaseTimeEntity {
         this.articleOwnerId = articleOwnerId;
         this.articleTag = tag;
         this.articleStatus = ArticleStatus.ACTIVATED;
-        this.commentCount = 0;
         this.likeCount = 0;
     }
 

--- a/src/main/java/com/numberone/backend/domain/article/entity/Article.java
+++ b/src/main/java/com/numberone/backend/domain/article/entity/Article.java
@@ -56,7 +56,7 @@ public class Article extends BaseTimeEntity {
 
     @ColumnDefault("0")
     @Comment("게시글 좋아요 개수")
-    private Integer likeCount; // todo: 동시성 처리
+    private Integer likeCount;
 
     @ColumnDefault("0")
     @Comment("게시글에 달린 댓글 개수")

--- a/src/main/java/com/numberone/backend/domain/article/entity/ArticleTag.java
+++ b/src/main/java/com/numberone/backend/domain/article/entity/ArticleTag.java
@@ -5,8 +5,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ArticleTag {
     LIFE, // 일상
-    FRAUD, // 사기
+    TRAFFIC, // 교통
     SAFETY, // 치안
-    REPORT; // 제보
+    NONE; // 기타
     private String value;
 }

--- a/src/main/java/com/numberone/backend/domain/article/service/ArticleService.java
+++ b/src/main/java/com/numberone/backend/domain/article/service/ArticleService.java
@@ -141,6 +141,7 @@ public class ArticleService {
 
 
         Optional<ArticleImage> thumbNailImage = articleImageRepository.findById(article.getThumbNailImageUrlId());
+        Long commentCount = commentRepository.countAllByArticle(articleId);
 
         String thumbNailImageUrl = "";
         if (thumbNailImage.isPresent()) {
@@ -152,7 +153,7 @@ public class ArticleService {
                 .stream().map(ArticleLike::getArticleId)
                 .toList();
 
-        return GetArticleDetailResponse.of(article, imageUrls, thumbNailImageUrl, owner, memberLikedArticleIdList);
+        return GetArticleDetailResponse.of(article, imageUrls, thumbNailImageUrl, owner, memberLikedArticleIdList, commentCount);
     }
 
     public Slice<GetArticleListResponse> getArticleListPaging(ArticleSearchParameter param, Pageable pageable) {
@@ -177,8 +178,9 @@ public class ArticleService {
 
         Optional<Member> owner = memberRepository.findById(ownerId);
         Optional<ArticleImage> articleImage = articleImageRepository.findById(thumbNailImageUrlId);
+        Long commentCount = commentRepository.countAllByArticle(articleInfo.getId());
 
-        articleInfo.updateInfo(owner, articleImage, memberLikedArticleIdList);
+        articleInfo.updateInfo(owner, articleImage, memberLikedArticleIdList, commentCount);
     }
 
     @Transactional
@@ -191,6 +193,8 @@ public class ArticleService {
         CommentEntity savedComment = commentRepository.save(
                 new CommentEntity(request.getContent(), article, member)
         );
+
+
 
         articleParticipantRepository.save(new ArticleParticipant(article, member));
         fcmMessageProvider.sendFcm(member, ARTICLE_COMMENT_FCM_ALARM, NotificationTag.COMMUNITY);

--- a/src/main/java/com/numberone/backend/domain/article/service/ArticleService.java
+++ b/src/main/java/com/numberone/backend/domain/article/service/ArticleService.java
@@ -14,6 +14,8 @@ import com.numberone.backend.domain.comment.dto.request.CreateCommentRequest;
 import com.numberone.backend.domain.comment.dto.response.CreateCommentResponse;
 import com.numberone.backend.domain.comment.entity.CommentEntity;
 import com.numberone.backend.domain.comment.repository.CommentRepository;
+import com.numberone.backend.domain.like.entity.ArticleLike;
+import com.numberone.backend.domain.like.repository.ArticleLikeRepository;
 import com.numberone.backend.domain.member.entity.Member;
 import com.numberone.backend.domain.member.repository.MemberRepository;
 import com.numberone.backend.domain.notification.entity.NotificationTag;
@@ -50,6 +52,7 @@ public class ArticleService {
     private final ArticleParticipantRepository articleParticipantRepository;
     private final ArticleImageRepository articleImageRepository;
     private final CommentRepository commentRepository;
+    private final ArticleLikeRepository articleLikeRepository;
     private final S3Provider s3Provider;
     private final LocationProvider locationProvider;
     private final FcmMessageProvider fcmMessageProvider;
@@ -68,6 +71,7 @@ public class ArticleService {
                         owner.getId(),
                         request.getArticleTag())
         );
+
         articleParticipantRepository.save(
                 new ArticleParticipant(article, owner)
         );
@@ -89,7 +93,7 @@ public class ArticleService {
                         new ArticleImage(article, imageUrl)
                 );
                 articleImages.add(savedArticleImage);
-                if (Objects.equals(i, request.getThumbNailImageIdx())) {
+                if (i == 0) {
                     thumbNailImageUrl = imageUrl;
                     thumbNailImageId = savedArticleImage.getId();
                 }
@@ -104,6 +108,7 @@ public class ArticleService {
         Double latitude = request.getLatitude();
         Double longitude = request.getLongitude();
         if (latitude != null && longitude != null) {
+            // 주소가 null 이 아닌 경우에만 api 요청하여 update
             String address = locationProvider.pos2address(request.getLatitude(), request.getLongitude());
             article.updateAddress(address);
         }
@@ -122,10 +127,12 @@ public class ArticleService {
 
     public GetArticleDetailResponse getArticleDetail(Long articleId) {
         String principal = SecurityContextProvider.getAuthenticatedUserEmail();
-        Member owner = memberRepository.findByEmail(principal)
+        Member member = memberRepository.findByEmail(principal) // 회원
                 .orElseThrow(NotFoundMemberException::new);
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(NotFoundArticleException::new);
+        Member owner = memberRepository.findById(article.getArticleOwnerId()) // 작성자
+                .orElseThrow(NotFoundMemberException::new);
 
         List<String> imageUrls = articleImageRepository.findByArticle(article)
                 .stream()
@@ -140,26 +147,38 @@ public class ArticleService {
             thumbNailImageUrl = thumbNailImage.get().getImageUrl();
         }
 
-        return GetArticleDetailResponse.of(article, imageUrls, thumbNailImageUrl, owner);
+        // 내가 좋아요 한 게시글의 ID 리스트
+        List<Long> memberLikedArticleIdList = articleLikeRepository.findByMember(member)
+                .stream().map(ArticleLike::getArticleId)
+                .toList();
+
+        return GetArticleDetailResponse.of(article, imageUrls, thumbNailImageUrl, owner, memberLikedArticleIdList);
     }
 
     public Slice<GetArticleListResponse> getArticleListPaging(ArticleSearchParameter param, Pageable pageable) {
+        String principal = SecurityContextProvider.getAuthenticatedUserEmail();
+        Member member = memberRepository.findByEmail(principal)
+                .orElseThrow(NotFoundMemberException::new);
+        List<Long> memberLikedArticleIdList = articleLikeRepository.findByMember(member)
+                .stream().map(ArticleLike::getArticleId)
+                .toList();
         return new SliceImpl<>(
                 articleRepository.getArticlesNoOffSetPaging(param, pageable)
                         .stream()
-                        .peek(this::updateArticleInfo)
-                        .toList()
-        );
+                        .peek(article -> {
+                            updateArticleInfo(article, memberLikedArticleIdList);
+                        })
+                        .toList());
     }
 
-    public void updateArticleInfo(GetArticleListResponse articleInfo) {
+    public void updateArticleInfo(GetArticleListResponse articleInfo, List<Long> memberLikedArticleIdList) {
         Long ownerId = articleInfo.getOwnerId();
         Long thumbNailImageUrlId = articleInfo.getThumbNailImageId();
 
         Optional<Member> owner = memberRepository.findById(ownerId);
         Optional<ArticleImage> articleImage = articleImageRepository.findById(thumbNailImageUrlId);
 
-        articleInfo.updateInfo(owner, articleImage);
+        articleInfo.updateInfo(owner, articleImage, memberLikedArticleIdList);
     }
 
     @Transactional

--- a/src/main/java/com/numberone/backend/domain/article/service/ArticleService.java
+++ b/src/main/java/com/numberone/backend/domain/article/service/ArticleService.java
@@ -194,11 +194,9 @@ public class ArticleService {
                 new CommentEntity(request.getContent(), article, member)
         );
 
-
-
         articleParticipantRepository.save(new ArticleParticipant(article, member));
+        // 게시글 작성자에게 알림을 보낸다.
         fcmMessageProvider.sendFcm(member, ARTICLE_COMMENT_FCM_ALARM, NotificationTag.COMMUNITY);
-
         return CreateCommentResponse.of(savedComment);
     }
 

--- a/src/main/java/com/numberone/backend/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/numberone/backend/domain/comment/controller/CommentController.java
@@ -2,12 +2,14 @@ package com.numberone.backend.domain.comment.controller;
 
 import com.numberone.backend.domain.comment.dto.request.CreateChildCommentRequest;
 import com.numberone.backend.domain.comment.dto.response.CreateChildCommentResponse;
+import com.numberone.backend.domain.comment.dto.response.DeleteCommentResponse;
 import com.numberone.backend.domain.comment.dto.response.GetCommentDto;
 import com.numberone.backend.domain.comment.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.sql.Delete;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -60,6 +62,11 @@ public class CommentController {
         return ResponseEntity.ok(response);
     }
 
-    // todo: 댓글 삭제, 가장 많은 좋아요 상단 고정, 대댓글 달리면 푸시 알람 전송, 상단 고정된 작성자에게 푸시알람 전송, 댓글 신고 기능
+    @DeleteMapping("{comment-id}")
+    public ResponseEntity<DeleteCommentResponse> deleteComment(@PathVariable("comment-id") Long commentId){
+        return ResponseEntity.ok(commentService.deleteComment(commentId));
+    }
+
+    // todo: 가장 많은 좋아요 상단 고정, 대댓글 달리면 푸시 알람 전송, 상단 고정된 작성자에게 푸시알람 전송, 댓글 신고 기능
 
 }

--- a/src/main/java/com/numberone/backend/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/numberone/backend/domain/comment/controller/CommentController.java
@@ -62,6 +62,13 @@ public class CommentController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "댓글 삭제 API 입니다", description = """
+            삭제할 댓글의 id 를 path variable 으로 보내주세요.
+            
+            대댓글이 존재하는 댓글을 삭제 요청하는 경우에는, 대댓글까지 모두 삭제됩니다.
+            
+            대댓글이 없는 댓글을 삭제 요청하는 경우에는 해당 댓글만 삭제됩니다.
+            """)
     @DeleteMapping("{comment-id}")
     public ResponseEntity<DeleteCommentResponse> deleteComment(@PathVariable("comment-id") Long commentId){
         return ResponseEntity.ok(commentService.deleteComment(commentId));

--- a/src/main/java/com/numberone/backend/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/numberone/backend/domain/comment/controller/CommentController.java
@@ -58,7 +58,7 @@ public class CommentController {
             """)
     @GetMapping("{article-id}")
     public ResponseEntity<List<GetCommentDto>> getCommentsByArticle(@PathVariable("article-id") Long articleId){
-        List<GetCommentDto> response = commentService.getCommentsByArticle(articleId); // todo: 해당 유저가 좋아요를 눌렀는지 여부까지 표시되도록 수정
+        List<GetCommentDto> response = commentService.getCommentsByArticle(articleId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/numberone/backend/domain/comment/dto/response/DeleteCommentResponse.java
+++ b/src/main/java/com/numberone/backend/domain/comment/dto/response/DeleteCommentResponse.java
@@ -1,0 +1,12 @@
+package com.numberone.backend.domain.comment.dto.response;
+
+import lombok.*;
+
+@ToString
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class DeleteCommentResponse {
+    private Long commentId;
+}

--- a/src/main/java/com/numberone/backend/domain/comment/dto/response/GetCommentDto.java
+++ b/src/main/java/com/numberone/backend/domain/comment/dto/response/GetCommentDto.java
@@ -32,6 +32,7 @@ public class GetCommentDto {
     private Long authorId;
     private String authorNickName;
     private String authorProfileImageUrl;
+    private boolean isLiked;
 
 
     @QueryProjection
@@ -47,7 +48,7 @@ public class GetCommentDto {
         this.likeCount = comment.getLikeCount();
     }
 
-    public void updateCommentInfo(Optional<Member> author){
+    public void updateCommentInfo(Optional<Member> author, List<Long> likedCommentIdList){
         author.ifPresentOrElse(
                 a -> {
                     this.authorNickName = a.getNickName();
@@ -57,6 +58,7 @@ public class GetCommentDto {
                     this.authorNickName = "알 수 없는 사용자";
                 }
         );
+        this.isLiked = likedCommentIdList.contains(commentId);
     }
 
 }

--- a/src/main/java/com/numberone/backend/domain/comment/entity/CommentEntity.java
+++ b/src/main/java/com/numberone/backend/domain/comment/entity/CommentEntity.java
@@ -31,7 +31,7 @@ public class CommentEntity extends BaseTimeEntity {
     private Integer depth;
 
     @Comment("댓글 좋아요 개수")
-    private Integer likeCount; // todo: 동시성 처리
+    private Integer likeCount;
 
     @Comment("댓글 내용")
     private String content;

--- a/src/main/java/com/numberone/backend/domain/comment/repository/custom/CommentRepositoryCustom.java
+++ b/src/main/java/com/numberone/backend/domain/comment/repository/custom/CommentRepositoryCustom.java
@@ -5,6 +5,7 @@ import com.numberone.backend.domain.comment.dto.response.GetCommentDto;
 import java.util.List;
 
 public interface CommentRepositoryCustom {
-    public List<GetCommentDto> findAllByArticle(Long articleId);
+    List<GetCommentDto> findAllByArticle(Long articleId);
+    Long countAllByArticle(Long articleId);
 
 }

--- a/src/main/java/com/numberone/backend/domain/comment/repository/custom/CommentRepositoryCustomImpl.java
+++ b/src/main/java/com/numberone/backend/domain/comment/repository/custom/CommentRepositoryCustomImpl.java
@@ -31,4 +31,15 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
                 )
                 .fetch();
     }
+
+
+    @Override
+    public Long countAllByArticle(Long articleId) {
+        return queryFactory.select(commentEntity.count())
+                .from(commentEntity)
+                .innerJoin(article, article)
+                .where(article.id.eq(articleId))
+                .fetchOne();
+
+    }
 }

--- a/src/main/java/com/numberone/backend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/numberone/backend/domain/comment/service/CommentService.java
@@ -6,6 +6,7 @@ import com.numberone.backend.domain.articleparticipant.entity.ArticleParticipant
 import com.numberone.backend.domain.articleparticipant.repository.ArticleParticipantRepository;
 import com.numberone.backend.domain.comment.dto.request.CreateChildCommentRequest;
 import com.numberone.backend.domain.comment.dto.response.CreateChildCommentResponse;
+import com.numberone.backend.domain.comment.dto.response.DeleteCommentResponse;
 import com.numberone.backend.domain.comment.dto.response.GetCommentDto;
 import com.numberone.backend.domain.comment.entity.CommentEntity;
 import com.numberone.backend.domain.comment.repository.CommentRepository;
@@ -91,6 +92,16 @@ public class CommentService {
         );
 
         return result;
+    }
+
+    @Transactional
+    public DeleteCommentResponse deleteComment(Long commentId){
+        CommentEntity commentEntity = commentRepository.findById(commentId)
+                .orElseThrow(NotFoundCommentException::new);
+        commentRepository.delete(commentEntity);
+        return DeleteCommentResponse.builder()
+                .commentId(commentId)
+                .build();
     }
 
 }

--- a/src/main/java/com/numberone/backend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/numberone/backend/domain/comment/service/CommentService.java
@@ -9,6 +9,8 @@ import com.numberone.backend.domain.comment.dto.response.CreateChildCommentRespo
 import com.numberone.backend.domain.comment.dto.response.GetCommentDto;
 import com.numberone.backend.domain.comment.entity.CommentEntity;
 import com.numberone.backend.domain.comment.repository.CommentRepository;
+import com.numberone.backend.domain.like.entity.CommentLike;
+import com.numberone.backend.domain.like.repository.CommentLikeRepository;
 import com.numberone.backend.domain.member.entity.Member;
 import com.numberone.backend.domain.member.repository.MemberRepository;
 import com.numberone.backend.domain.token.util.SecurityContextProvider;
@@ -32,6 +34,7 @@ public class CommentService {
     private final ArticleRepository articleRepository;
     private final ArticleParticipantRepository articleParticipantRepository;
     private final MemberRepository memberRepository;
+    private final CommentLikeRepository commentLikeRepository;
 
     @Transactional
     public CreateChildCommentResponse createChildComment(
@@ -56,10 +59,15 @@ public class CommentService {
     }
 
     public List<GetCommentDto> getCommentsByArticle(Long articleId) {
+        String principal = SecurityContextProvider.getAuthenticatedUserEmail();
+        Member member = memberRepository.findByEmail(principal)
+                .orElseThrow(NotFoundMemberException::new);
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(NotFoundArticleException::new);
         List<GetCommentDto> comments = commentRepository.findAllByArticle(article.getId());
-
+        List<Long> likedCommentIdList = commentLikeRepository.findByMember(member)
+                .stream().map(CommentLike::getCommentId)
+                .toList();
         // 계층 구조로 변환 (추후 리팩토링 필요)
         List<GetCommentDto> result = new ArrayList<>();
         Map<Long, GetCommentDto> map = new HashMap<>();
@@ -68,7 +76,7 @@ public class CommentService {
                     CommentEntity commentEntity = commentRepository.findById(comment.getCommentId())
                             .orElseThrow(NotFoundCommentException::new);
                     Optional<Member> author = memberRepository.findById(commentEntity.getAuthorId());
-                    comment.updateCommentInfo(author);
+                    comment.updateCommentInfo(author, likedCommentIdList);
 
                     map.put(comment.getCommentId(), comment);
 

--- a/src/main/java/com/numberone/backend/domain/like/service/LikeService.java
+++ b/src/main/java/com/numberone/backend/domain/like/service/LikeService.java
@@ -57,7 +57,7 @@ public class LikeService {
         article.increaseLikeCount();
         articleLikeRepository.save(new ArticleLike(member, article));
 
-        if (article.getLikeCount() > BEST_ARTICLE_LIKE_COUNT) {
+        if (article.getLikeCount() >= BEST_ARTICLE_LIKE_COUNT) {
             Long ownerId = article.getArticleOwnerId();
             Member owner = memberRepository.findById(ownerId)
                     .orElseThrow(NotFoundMemberException::new);

--- a/src/main/java/com/numberone/backend/domain/like/service/LikeService.java
+++ b/src/main/java/com/numberone/backend/domain/like/service/LikeService.java
@@ -10,18 +10,23 @@ import com.numberone.backend.domain.like.repository.ArticleLikeRepository;
 import com.numberone.backend.domain.like.repository.CommentLikeRepository;
 import com.numberone.backend.domain.member.entity.Member;
 import com.numberone.backend.domain.member.repository.MemberRepository;
+import com.numberone.backend.domain.notification.entity.NotificationTag;
 import com.numberone.backend.domain.token.util.SecurityContextProvider;
 import com.numberone.backend.exception.conflict.AlreadyLikedException;
 import com.numberone.backend.exception.conflict.AlreadyUnLikedException;
 import com.numberone.backend.exception.notfound.NotFoundApiException;
 import com.numberone.backend.exception.notfound.NotFoundCommentException;
 import com.numberone.backend.exception.notfound.NotFoundMemberException;
+import com.numberone.backend.support.fcm.service.FcmMessageProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.id.IntegralDataTypeHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static com.numberone.backend.support.notification.NotificationMessage.BEST_ARTICLE_FCM_ALARM;
 
 @Slf4j
 @Service
@@ -34,7 +39,9 @@ public class LikeService {
     private final CommentLikeRepository commentLikeRepository;
     private final CommentRepository commentRepository;
     private final MemberRepository memberRepository;
+    private final FcmMessageProvider fcmMessageProvider;
 
+    private final Integer BEST_ARTICLE_LIKE_COUNT = 20;
 
     @Transactional
     public Integer increaseArticleLike(Long articleId) {
@@ -49,6 +56,13 @@ public class LikeService {
         }
         article.increaseLikeCount();
         articleLikeRepository.save(new ArticleLike(member, article));
+
+        if (article.getLikeCount() > BEST_ARTICLE_LIKE_COUNT) {
+            Long ownerId = article.getArticleOwnerId();
+            Member owner = memberRepository.findById(ownerId)
+                    .orElseThrow(NotFoundMemberException::new);
+            fcmMessageProvider.sendFcm(owner, BEST_ARTICLE_FCM_ALARM, NotificationTag.COMMUNITY);
+        }
 
         return article.getLikeCount();
     }
@@ -97,7 +111,7 @@ public class LikeService {
                 .orElseThrow(NotFoundMemberException::new);
         CommentEntity commentEntity = commentRepository.findById(commentId)
                 .orElseThrow(NotFoundCommentException::new);
-        if (!isAlreadyLikedComment(member, commentId)){
+        if (!isAlreadyLikedComment(member, commentId)) {
             // 좋아요를 누르지 않은 댓글이라 좋아요를 취소할 수 없습니다.
             throw new AlreadyUnLikedException();
         }

--- a/src/main/java/com/numberone/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/numberone/backend/domain/member/controller/MemberController.java
@@ -28,6 +28,7 @@ import java.net.URI;
 @Slf4j
 @Tag(name = "members", description = "사용자 관련 API")
 @RestController
+@RequestMapping("/api/members")
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;

--- a/src/main/java/com/numberone/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/numberone/backend/domain/member/controller/MemberController.java
@@ -29,7 +29,6 @@ import java.net.URI;
 @Tag(name = "members", description = "사용자 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/members")
 public class MemberController {
     private final MemberService memberService;
 

--- a/src/main/java/com/numberone/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/numberone/backend/domain/member/entity/Member.java
@@ -25,7 +25,6 @@ import java.util.List;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@RequestMapping("/api/members")
 @Table(name = "MEMBER")
 public class Member extends BaseTimeEntity {
     @Id

--- a/src/main/java/com/numberone/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/numberone/backend/domain/member/entity/Member.java
@@ -16,6 +16,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +25,7 @@ import java.util.List;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@RequestMapping("/api/members")
 @Table(name = "MEMBER")
 public class Member extends BaseTimeEntity {
     @Id

--- a/src/main/java/com/numberone/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/numberone/backend/domain/member/service/MemberService.java
@@ -46,8 +46,8 @@ public class MemberService {
     public void initMemberData(String email, OnboardingRequest onboardingRequest) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
-        member.setOnboardingData(onboardingRequest.getNickname(), onboardingRequest.getFcmToken());
         notificationDisasterRepository.deleteAllByMemberId(member.getId());
+        member.setOnboardingData(onboardingRequest.getNickname(), onboardingRequest.getFcmToken());
         notificationRegionRepository.deleteAllByMemberId(member.getId());
         for (OnboardingAddress address : onboardingRequest.getAddresses()) {
             notificationRegionRepository.save(NotificationRegion.of(

--- a/src/main/java/com/numberone/backend/support/fcm/service/FcmMessageProvider.java
+++ b/src/main/java/com/numberone/backend/support/fcm/service/FcmMessageProvider.java
@@ -27,6 +27,7 @@ public class FcmMessageProvider {
         String token = member.getFcmToken();
         if (Objects.isNull(token)){
             log.error("해당 회원의 fcm 토큰이 존재하지 않아, 푸시알람을 전송할 수 없습니다.");
+            // todo : 예외 핸들링
            return;
         }
 

--- a/src/main/java/com/numberone/backend/support/notification/NotificationMessage.java
+++ b/src/main/java/com/numberone/backend/support/notification/NotificationMessage.java
@@ -7,7 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum NotificationMessage implements NotificationMessageSpec {
 
-    ARTICLE_COMMENT_FCM_ALARM("[대피로 알림]", "게시글에 댓글이 달렸어요!", null);
+    ARTICLE_COMMENT_FCM_ALARM("[대피로 알림]", "게시글에 댓글이 달렸어요!", null),
+    BEST_ARTICLE_FCM_ALARM("[대피로 알림]", "축하드립니다! 베스트 게시글로 선정되었습니다. 🎉", null);
+    ;
 
     private final String title;
     private final String body;


### PR DESCRIPTION
### 작업내용
1. **게시글 카테고리 관련**
게시글 태그 (카테고리) 를 기획에서 확정된 내용으로 변경
  - LIFE(일상), TRAFFIC(교통), SAFETY(치안), NONE(기타)
  
2. **게시글 작성 관련**
- 게시물 작성 시, 가장 첫 번째로 보낸 이미지가 썸네일로 처리되도록 변경
- 게시물 작성 시, MultipartFile 이 올라가지 않던 버그 수정 ( RequestBody -> ModelAttribute )

3. **네이밍 일부 변경**
현재 서비스에서 네이밍이 혼용되고 있는 것 같아, 이부분  시간날때 바로잡고 가면 좋을 듯 합니다!
- owner / auther / member
- 토요일에 고고하면 좋을 듯 합니당

5. **게시글, 댓글 조회 시, 좋아요 눌렀는지 여부를 반환**
게시글, 댓글 리스트 조회 시 내가 좋아요를 눌렀는지 여부(isLiked) 를 반환합니다. 작성자의 프로필 사진 url 도 응답하도록 하였습니다.

6. **게시글 리스트 조회 시 comment Count 를 반환**
게시글 엔티티에서 commentCount 를 관리하려고 했었는데, 부모 댓글이 삭제되면 자식 댓글들도 삭제되는 요구사항이 있어서 commentCount 를 어떻게 관리해야 할 지 고민을 조금 했었습니다. 댓글이 작성되거나 삭제될 때 해당 게시글의 commentCount 를 갱신하는 방법과,  게시글을 조회하는 시점에서 댓글의 개수를 count 해서 응답하는 방법 중 후자가 조금 더 관리하기 쉬울 것으로 생각이 되어, 조회 시점에 댓글 개수를 카운팅하도록 구현하였습니다. 이에 따라 Article 엔티티 내에 존재하던 commentCount 필드는 더이상 필요하지 않게 되어 제거하였습니다.

7. **댓글 삭제 api **
 댓글 삭제 api 를 구현하였습니다. orphan removal 옵션을 true 로 주어, 부모 엔티티가 제거되는 경우에 자식 엔티티 까지 모두 제거되도록 하였습니다.
 
 ---
 
### todo
 - 댓글, 게시글 신고 기능
 - 베스트 게시글 기능
 - 시간이 난다면 배포 파이프라인 튜닝..
 - 커뮤니티 접근을 지역별로 제한해야하는데, 어떻게 해야하는지 고민 중...