### PR TITLE
Feat: 배포 프로세스 최적화 및 jib 적용하여 배포 시간 단축

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,7 +4,7 @@ name: NumberOne-Backend-CICD
 # event trigger
 on:
   push:
-    branches: [ "main", "dev", "dev-check"]
+    branches: [ " " ] # none
 
 permissions: write-all
 

--- a/.github/workflows/jib-build-depoly.yml
+++ b/.github/workflows/jib-build-depoly.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build with jib
         run: |
-          ./gradlew jib \
+          ./gradlew jib -x test \
           -Djib.to.auth.username=${{ secrets.DOCKER_USERNAME }} \
           -Djib.to.auth.password=${{ secrets.DOCKER_PASSWORD }} \
           -Djib.to.image="${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}:${GITHUB_REF##*/}"

--- a/.github/workflows/jib-build-depoly.yml
+++ b/.github/workflows/jib-build-depoly.yml
@@ -1,0 +1,115 @@
+# github repository Actions 페이지에 나타낼 이름
+name: NumberOne-Backend-JIB-BUILD-DEPLOY
+
+# event trigger
+on:
+  push:
+    branches: [ "main", "dev", "dev-check" ]
+
+permissions: write-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      ## jdk setting
+      - uses: actions/checkout@v3
+      - name: 🧱 Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin' # https://github.com/actions/setup-java
+
+      ## gradle caching
+      - name: 🐧 Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: 🐧 Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: 🔑 Login to Docker Hub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build with jib
+        run: |
+          ./gradlew jib \
+          -Djib.to.auth.username=${{ secrets.DOCKER_USERNAME }} \
+          -Djib.to.auth.password=${{ secrets.DOCKER_PASSWORD }} \
+          -Djib.to.image="${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}:${GITHUB_REF##*/}"
+
+      - name: Get current time
+        uses: 1466587594/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYY-MM-DDTHH-mm-ss
+          utcOffset: "+09:00"
+
+      - name: Show Current Time
+        run: echo "CurrentTime=${{steps.current-time.outputs.formattedTime}}"
+        shell: bash
+
+
+      - name:  🐙 docker-compose.yml to EC2 server
+        uses: appleboy/scp-action@master
+        with:
+          username: ubuntu
+          host: ${{ secrets.EC2_HOST }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          port: ${{ secrets.EC2_PORT }}
+          envs: GITHUB_SHA
+          source: "./docker-compose.yml"
+          target: "/home/ubuntu/"
+          overwrite: true
+          timeout: 1m
+
+      - name: 🐧 create application.yml
+        run: |
+          mkdir ./src/main/resources
+          cd ./src/main/resources
+          touch ./application.yml
+          echo "${{ secrets.PROPERTIES_PROD }}" | base64 --decode > ./application.yml
+          ls -la
+        shell: bash
+
+      - name: 🐧 create service-account.json
+        run: |
+          cd ./src/main/resources
+          touch ./service-account.json
+          echo "${{ secrets.FCM }}" | base64 --decode > ./service-account.json
+          ls -la
+        shell: bash
+
+      ## deploy to production
+      - name: 🌿 Deploy
+        uses: appleboy/ssh-action@master
+        id: deploy-prod
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          envs: GITHUB_SHA
+          script: |
+            sudo docker rm -f $(docker ps -qa)
+            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}:${GITHUB_REF##*/}
+            docker-compose up -d
+            docker image prune -f
+
+      ## notify at Slack
+      - name: 🔔 Send Slack Message
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo, message, commit, author, action, eventName, ref, workflow, pullRequest
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()

--- a/.github/workflows/jib-build-depoly.yml
+++ b/.github/workflows/jib-build-depoly.yml
@@ -28,7 +28,7 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
+            ${{ runner.os }}-gradle-          
 
       - name: 🐧 Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -38,24 +38,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Build with jib
-        run: |
-          ./gradlew jib -x test \
-          -Djib.to.auth.username=${{ secrets.DOCKER_USERNAME }} \
-          -Djib.to.auth.password=${{ secrets.DOCKER_PASSWORD }} \
-          -Djib.to.image="${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}"
-
-      - name: Get current time
-        uses: 1466587594/get-current-time@v2
-        id: current-time
-        with:
-          format: YYYY-MM-DDTHH-mm-ss
-          utcOffset: "+09:00"
-
-      - name: Show Current Time
-        run: echo "CurrentTime=${{steps.current-time.outputs.formattedTime}}"
-        shell: bash
 
       - name: 🐧 create application.yml
         run: |
@@ -72,6 +54,24 @@ jobs:
           touch ./service-account.json
           echo "${{ secrets.FCM }}" | base64 --decode > ./service-account.json
           ls -la
+        shell: bash
+
+      - name: Build with jib
+        run: |
+          ./gradlew jib -x test \
+          -Djib.to.auth.username=${{ secrets.DOCKER_USERNAME }} \
+          -Djib.to.auth.password=${{ secrets.DOCKER_PASSWORD }} \
+          -Djib.to.image="${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}:latest"
+
+      - name: Get current time
+        uses: 1466587594/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYY-MM-DDTHH-mm-ss
+          utcOffset: "+09:00"
+
+      - name: Show Current Time
+        run: echo "CurrentTime=${{steps.current-time.outputs.formattedTime}}"
         shell: bash
 
       ## deploy to production

--- a/.github/workflows/jib-build-depoly.yml
+++ b/.github/workflows/jib-build-depoly.yml
@@ -1,4 +1,3 @@
-# github repository Actions 페이지에 나타낼 이름
 name: NumberOne-Backend-JIB-BUILD-DEPLOY
 
 # event trigger

--- a/.github/workflows/jib-build-depoly.yml
+++ b/.github/workflows/jib-build-depoly.yml
@@ -44,7 +44,7 @@ jobs:
           ./gradlew jib -x test \
           -Djib.to.auth.username=${{ secrets.DOCKER_USERNAME }} \
           -Djib.to.auth.password=${{ secrets.DOCKER_PASSWORD }} \
-          -Djib.to.image="${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}:${GITHUB_REF##*/}"
+          -Djib.to.image="${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}"
 
       - name: Get current time
         uses: 1466587594/get-current-time@v2
@@ -85,7 +85,7 @@ jobs:
           envs: GITHUB_SHA
           script: |
             sudo docker rm -f $(docker ps -qa)
-            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}:${GITHUB_REF##*/}
+            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}:latest
             docker-compose up -d
             docker image prune -f
 

--- a/.github/workflows/jib-build-depoly.yml
+++ b/.github/workflows/jib-build-depoly.yml
@@ -58,20 +58,6 @@ jobs:
         run: echo "CurrentTime=${{steps.current-time.outputs.formattedTime}}"
         shell: bash
 
-
-      - name:  🐙 docker-compose.yml to EC2 server
-        uses: appleboy/scp-action@master
-        with:
-          username: ubuntu
-          host: ${{ secrets.EC2_HOST }}
-          key: ${{ secrets.EC2_PRIVATE_KEY }}
-          port: ${{ secrets.EC2_PORT }}
-          envs: GITHUB_SHA
-          source: "./docker-compose.yml"
-          target: "/home/ubuntu/"
-          overwrite: true
-          timeout: 1m
-
       - name: 🐧 create application.yml
         run: |
           mkdir ./src/main/resources

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ jib {
 		tags = ["latest"]
 	}
 	container {
-		jvmFlags = ["-Duser.timezone=Asia/Seoul", "-Xms2048m", "-Xmx2048m"]
+		jvmFlags = ["-Duser.timezone=Asia/Seoul", "-Xms128m", "-Xmx128m"]
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.4'
 	id 'io.spring.dependency-management' version '1.1.3'
-	id 'com.google.cloud.tools.jib' version '3.3.1'
+	id 'com.google.cloud.tools.jib' version '3.4.0'
 }
 
 group = 'com.numberone'
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 jib {
 	from {
-		image = "eclipse-temurin:17-jre"
+		image = "openjdk:17-alpine"
 	}
 	to {
 		image = "versatile0010/numberone"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.4'
 	id 'io.spring.dependency-management' version '1.1.3'
-	id 'com.google.cloud.tools.jib' version '3.2.0'
+	id 'com.google.cloud.tools.jib' version '3.3.1'
 }
 
 group = 'com.numberone'

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,27 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.4'
 	id 'io.spring.dependency-management' version '1.1.3'
+	id 'com.google.cloud.tools.jib' version '3.2.0'
 }
 
 group = 'com.numberone'
 version = '0.0.1-SNAPSHOT'
+
+jib {
+	from {
+		image = "eclipse-temurin:17-jre"
+	}
+	to {
+		image = "versatile0010/numberone"
+		credHelper = 'ecr-login'
+		tags = ["latest"]
+	}
+	container {
+		jvmFlags = ["-Duser.timezone=Asia/Seoul", "-Xms2048m", "-Xmx2048m"]
+	}
+}
+
+
 
 java {
 	sourceCompatibility = '17'

--- a/src/main/java/com/numberone/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/numberone/backend/config/SwaggerConfig.java
@@ -15,7 +15,7 @@ import org.springframework.http.HttpHeaders;
 @OpenAPIDefinition(
         servers = @Server(url = "/", description = "${host.url}"),
         info = @Info(
-                title = "🚀 대피로 백엔드 API 명세서",
+                title = "🚀 대피로 백엔드 API 명세서 11.18. 02:32 Jib 배포 버전",
                 description = """
                         spring docs 를 이용한 API 명세서 입니다.😊
                         """,

--- a/src/main/java/com/numberone/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/numberone/backend/config/SwaggerConfig.java
@@ -15,7 +15,7 @@ import org.springframework.http.HttpHeaders;
 @OpenAPIDefinition(
         servers = @Server(url = "/", description = "${host.url}"),
         info = @Info(
-                title = "🚀 대피로 백엔드 API 명세서 11.18. 02:32 Jib 배포 버전",
+                title = "🚀 대피로 백엔드 API 명세서 Jib 배포 23. 11. 18. v1",
                 description = """
                         spring docs 를 이용한 API 명세서 입니다.😊
                         """,

--- a/src/main/java/com/numberone/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/numberone/backend/config/SwaggerConfig.java
@@ -15,9 +15,8 @@ import org.springframework.http.HttpHeaders;
 @OpenAPIDefinition(
         servers = @Server(url = "/", description = "${host.url}"),
         info = @Info(
-                title = "🚀 대피로 백엔드 API 명세서 Jib 배포 23. 11. 18. v1",
+                title = "🚀 대피로 백엔드 API 명세서 Jib 배포 23. 11. 18. v1 (jdk base image = openjdk:17-alpine)",
                 description = """
-                        jdk base image = openjdk:17-alpine
                         spring docs 를 이용한 API 명세서 입니다.😊
                         """,
                 version = "1.0",

--- a/src/main/java/com/numberone/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/numberone/backend/config/SwaggerConfig.java
@@ -17,6 +17,7 @@ import org.springframework.http.HttpHeaders;
         info = @Info(
                 title = "🚀 대피로 백엔드 API 명세서 Jib 배포 23. 11. 18. v1",
                 description = """
+                        jdk base image = openjdk:17-alpine
                         spring docs 를 이용한 API 명세서 입니다.😊
                         """,
                 version = "1.0",


### PR DESCRIPTION
- 작업 전 (대략 1분 후반 ~ 4분 초반 소요됨)
<img width="458" alt="image" src="https://github.com/Kusitms-NumberOne/Backend/assets/96612168/3b552283-5677-4da2-a2f8-5c31145aab17">


- 작업 후 (대략 30초 초 중반 ~ 40초 후반 소요됨)
<img width="661" alt="image" src="https://github.com/Kusitms-NumberOne/Backend/assets/96612168/d453c8dc-0bf9-4e47-a757-ca3ef58134a0">

---

## 트러블 슈팅 

배포가 최신 이미지로 안되고, 이전 이미지로 서버에 반영되는 문제 발생..
원인은 ec2 메모리 부족으로 인해 docker image pull 이 안되고 기존에 존재하던 (구) 이미지에 대해서 컨테이너화를 시키고 있었음..
 ( ssh 접속해서 확인해보니 가용 메모리가 20 MB 였던...)

-> ec2 볼륨을 8GB 에서 16GB 으로 확장함.

프리티어는 최대 30GM 까지 무료라고 하는데, 일단 16 GB 로 늘려놓고 지켜보다가 늘리면 좋을 듯 함
( 볼륨 확장은 쉬운 편이지만, 축소는 매우 번거롭다고 함)

---
위 문제는 해결했지만, 스프링 부트에 환경변수 주입이 안되고 있는 문제 발생..

-> 배포 스크립트 순서 상의 문제였음

application.yml 과 service-account.json 파일을 셋팅하는 부분 뒤에 

jib 빌드를 수행하도록 해서 해결함..
---